### PR TITLE
Add role service

### DIFF
--- a/src/app/core/header/navigation/README.md
+++ b/src/app/core/header/navigation/README.md
@@ -14,9 +14,6 @@ The nav is not rendered at all if the viewport width is <= 500px.
 
 ## Methods and getters
 
-### ``isGuest`` (getter)
-Returns ``true`` if the user's roles array in the user state is empty, ``false`` otherwise.
-
 ### ``getInnerWidth``
 ```typescript
 function getInnerWidth(): number

--- a/src/app/core/header/navigation/navigation.component.spec.ts
+++ b/src/app/core/header/navigation/navigation.component.spec.ts
@@ -2,86 +2,16 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { NavigationComponent } from './navigation.component';
 import { AppStoreModule } from '../../../store/app-store.module';
-import { RouterModule } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
 import { Store } from '@ngrx/store';
 import { IAppStore } from '../../../../types/store/store.types';
 import { restartUser, setUser } from '../../../store/user/user.action';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
-import { HttpClient } from '@angular/common/http';
-import { AuthService } from '../../auth-service/auth.service';
 
 describe('NavigationComponent', () => {
   let component: NavigationComponent;
   let fixture: ComponentFixture<NavigationComponent>;
   let store: Store<IAppStore>;
-
-  describe('Unit tests', () => {
-    beforeEach(() => {
-      TestBed.configureTestingModule({
-        imports: [
-          NavigationComponent,
-          AppStoreModule,
-          RouterTestingModule,
-          HttpClientTestingModule
-        ],
-      });
-
-      fixture = TestBed.createComponent(NavigationComponent);
-      component = fixture.componentInstance;
-      store = TestBed.inject(Store<IAppStore>);
-      fixture.detectChanges();
-    });
-
-    describe('isGuest', () => {
-      it('Returns true if the userRoles array is empty', () => {
-        component.userRoles = [];
-        const result = component.isGuest;
-        expect(result).toBe(true);
-      });
-
-      it('Returns false if the userRoles array is not empty', () => {
-        component.userRoles = ['User'];
-        const result = component.isGuest;
-        expect(result).toBe(false);
-      });
-    });
-  });
-
-  describe('Integration tests', () => {
-    beforeEach(() => {
-      TestBed.configureTestingModule({
-        imports: [
-          NavigationComponent,
-          AppStoreModule,
-          RouterTestingModule,
-          HttpClientTestingModule
-        ],
-        providers: [
-          AuthService
-        ]
-      });
-
-      fixture = TestBed.createComponent(NavigationComponent);
-      component = fixture.componentInstance;
-      store = TestBed.inject(Store<IAppStore>);
-      fixture.detectChanges();
-    });
-
-    describe('isGuest', () => {
-      it('Correctly tracks the user state', () => {
-        expect(component.isGuest).toBe(true);
-
-        store.dispatch(setUser({ id: 1, username: 'some username', roles: ['User'] }));
-
-        expect(component.isGuest).toBe(false);
-
-        store.dispatch(restartUser());
-
-        expect(component.isGuest).toBe(true)
-      });
-    });
-  });
 
   describe('Component tests', () => {
     beforeEach(() => {

--- a/src/app/core/header/navigation/navigation.component.ts
+++ b/src/app/core/header/navigation/navigation.component.ts
@@ -7,6 +7,7 @@ import { RouterModule } from '@angular/router';
 import { role } from '../../../../types/auth/roles.types';
 import { MatIconModule } from '@angular/material/icon';
 import { LogoutButtonModule } from './logout-button/logout-button.module';
+import { RoleService } from '../../role-service/role.service';
 
 @Component({
   selector: 'app-navigation',
@@ -20,22 +21,18 @@ import { LogoutButtonModule } from './logout-button/logout-button.module';
   templateUrl: './navigation.component.html',
   styleUrls: ['./navigation.component.scss']
 })
-export class NavigationComponent implements OnInit {
-  constructor(private readonly store: Store<IAppStore>) { }
-  ngOnInit(): void {
-    this.store.select(selectUserRoles).subscribe(state => {
-      this.userRoles = state;
-    });
-  }
-
-  userRoles!: role[];
+export class NavigationComponent {
+  constructor(
+    private readonly store: Store<IAppStore>,
+    private readonly roleService: RoleService,
+    ) { }
 
   /**
    * Returns ``true`` if the ``userRoles`` property is an empty array,
    * otherwise returns ``false``
    */
-  get isGuest() {
-    return this.userRoles.length === 0;
+  protected get isGuest() {
+    return this.roleService.isGuest();
   }
 
   /**

--- a/src/app/core/role-service/README.md
+++ b/src/app/core/role-service/README.md
@@ -5,3 +5,9 @@ has a certain role and what their highest role is.
 
 When the service is initialized via the constructor, the user's roles are set in
 the ``userRoles`` property.
+
+## Methods
+```typescript
+function isAdmin(): boolean
+```
+Returns a boolean value that indicates whether ``userRoles`` contains ``Administrator``.

--- a/src/app/core/role-service/README.md
+++ b/src/app/core/role-service/README.md
@@ -16,3 +16,8 @@ Returns a boolean value that indicates whether ``userRoles`` contains ``Administ
 function isModerator(): boolean
 ```
 Returns a boolean value that indicates whether ``userRoles`` contains ``Moderator``.
+
+```typescript
+function isGuest(): boolean
+```
+Returns a boolean value that indicates whether ``userRoles`` is empty.

--- a/src/app/core/role-service/README.md
+++ b/src/app/core/role-service/README.md
@@ -27,3 +27,9 @@ function isLoggedIn(): boolean;
 function isLoggedIn(strategy: 'store' | 'localStorage'): boolean;
 ```
 Returns a boolean value that indicates whether the user is logged in or not. By default, the method determines that by checking if ``userRoles`` is empty or not. If you want this to be determined by whether the user has a JWT in the ``localStorage``, pass ``'localStorage'`` as an argument. It's recommended to use the store strategy whenever possible.
+
+```typescript
+function getHighestRole(): role | null;
+```
+Returns the user's "highest" role. For example, if the user has the Administrator and Moderator roles, this method will return "Administrator". ``null`` is returned
+if the user is not logged in.

--- a/src/app/core/role-service/README.md
+++ b/src/app/core/role-service/README.md
@@ -1,0 +1,7 @@
+# RoleService
+
+An injectable service to work with roles, such as verifying if the user
+has a certain role and what their highest role is.
+
+When the service is initialized via the constructor, the user's roles are set in
+the ``userRoles`` property.

--- a/src/app/core/role-service/README.md
+++ b/src/app/core/role-service/README.md
@@ -21,3 +21,9 @@ Returns a boolean value that indicates whether ``userRoles`` contains ``Moderato
 function isGuest(): boolean
 ```
 Returns a boolean value that indicates whether ``userRoles`` is empty.
+
+```typescript
+function isLoggedIn(): boolean;
+function isLoggedIn(strategy: 'store' | 'localStorage'): boolean;
+```
+Returns a boolean value that indicates whether the user is logged in or not. By default, the method determines that by checking if ``userRoles`` is empty or not. If you want this to be determined by whether the user has a JWT in the ``localStorage``, pass ``'localStorage'`` as an argument. It's recommended to use the store strategy whenever possible.

--- a/src/app/core/role-service/README.md
+++ b/src/app/core/role-service/README.md
@@ -11,3 +11,8 @@ the ``userRoles`` property.
 function isAdmin(): boolean
 ```
 Returns a boolean value that indicates whether ``userRoles`` contains ``Administrator``.
+
+```typescript
+function isModerator(): boolean
+```
+Returns a boolean value that indicates whether ``userRoles`` contains ``Moderator``.

--- a/src/app/core/role-service/role.service.spec.ts
+++ b/src/app/core/role-service/role.service.spec.ts
@@ -5,6 +5,7 @@ import { AppStoreModule } from '../../store/app-store.module';
 import { Store } from '@ngrx/store';
 import { IAppStore } from '../../../types/store/store.types';
 import { setUser } from '../../store/user/user.action';
+import { roles } from '../../constants/roles.constants';
 
 describe('RoleService', () => {
   let service: RoleService;
@@ -32,4 +33,22 @@ describe('RoleService', () => {
     const newService = TestBed.inject(RoleService);
     expect(newService.userRoles).toEqual(['User']);
   }));
+
+  describe('isAdmin', () => {
+    it('Returns true if userRoles contains Administrator', () => {
+      service.userRoles = [roles.admin];
+      expect(service.isAdmin()).toBeTrue();
+
+      service.userRoles = [roles.admin, roles.moderator];
+      expect(service.isAdmin()).toBeTrue();
+    });
+
+    it('Returns false if the user is not an administrator', () => {
+      service.userRoles = [];
+      expect(service.isAdmin()).toBeFalse();
+
+      service.userRoles = [roles.moderator, roles.user];
+      expect(service.isAdmin()).toBeFalse();
+    });
+  });
 });

--- a/src/app/core/role-service/role.service.spec.ts
+++ b/src/app/core/role-service/role.service.spec.ts
@@ -81,4 +81,39 @@ describe('RoleService', () => {
       expect(service.isGuest()).toBeFalse();
     });
   });
+
+  describe('isLoggedIn', () => {
+    it('Returns true if userRoles is not empty (store strategy)', () => {
+      service.userRoles = [roles.user];
+      localStorage.removeItem('token');
+      expect(service.isLoggedIn()).toBeTrue();
+
+      expect(service.isLoggedIn('store')).toBeTrue();
+    });
+
+    it('Returns true if localStorage token is not null (localStorage strategy)', () => {
+      service.userRoles = [];
+      localStorage.setItem('token', 'a');
+      expect(service.isLoggedIn('localStorage')).toBeTrue();
+    });
+
+    it('Returns false if userRoles is empty (store strategy)', () => {
+      service.userRoles = [];
+      localStorage.setItem('token', 'a');
+
+      expect(service.isLoggedIn()).toBeFalse();
+      expect(service.isLoggedIn('store')).toBeFalse();
+    });
+
+    it('Returns false if userRoles is empty (localStorage is empty)', () => {
+      service.userRoles = [roles.user];
+      localStorage.removeItem('token');
+
+      expect(service.isLoggedIn('localStorage')).toBeFalse();
+    });
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+  })
 });

--- a/src/app/core/role-service/role.service.spec.ts
+++ b/src/app/core/role-service/role.service.spec.ts
@@ -51,4 +51,22 @@ describe('RoleService', () => {
       expect(service.isAdmin()).toBeFalse();
     });
   });
+
+  describe('isModerator', () => {
+    it('Returns true if userRoles contains Moderator', () => {
+      service.userRoles = [roles.moderator];
+      expect(service.isModerator()).toBeTrue();
+
+      service.userRoles = [roles.admin, roles.moderator];
+      expect(service.isModerator()).toBeTrue();
+    });
+
+    it('Returns false if the user is not a moderator', () => {
+      service.userRoles = [];
+      expect(service.isModerator()).toBeFalse();
+
+      service.userRoles = [roles.user];
+      expect(service.isModerator()).toBeFalse();
+    });
+  });
 });

--- a/src/app/core/role-service/role.service.spec.ts
+++ b/src/app/core/role-service/role.service.spec.ts
@@ -69,4 +69,16 @@ describe('RoleService', () => {
       expect(service.isModerator()).toBeFalse();
     });
   });
+
+  describe('isGuestr', () => {
+    it('Returns true if userRoles is empty', () => {
+      service.userRoles = [];
+      expect(service.isGuest()).toBeTrue();
+    });
+
+    it('Returns false if userRoles is not empty', () => {
+      service.userRoles = [roles.user];
+      expect(service.isGuest()).toBeFalse();
+    });
+  });
 });

--- a/src/app/core/role-service/role.service.spec.ts
+++ b/src/app/core/role-service/role.service.spec.ts
@@ -1,0 +1,35 @@
+import { TestBed, waitForAsync } from '@angular/core/testing';
+
+import { RoleService } from './role.service';
+import { AppStoreModule } from '../../store/app-store.module';
+import { Store } from '@ngrx/store';
+import { IAppStore } from '../../../types/store/store.types';
+import { setUser } from '../../store/user/user.action';
+
+describe('RoleService', () => {
+  let service: RoleService;
+  let store: Store<IAppStore>;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [AppStoreModule]
+    });
+    service = TestBed.inject(RoleService);
+    store = TestBed.inject(Store);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  it('sets userRoles on initialization', waitForAsync(() => {
+    store.dispatch(setUser({
+      id: 1,
+      username: 'a',
+      roles: ['User']
+    }));
+
+    const newService = TestBed.inject(RoleService);
+    expect(newService.userRoles).toEqual(['User']);
+  }));
+});

--- a/src/app/core/role-service/role.service.spec.ts
+++ b/src/app/core/role-service/role.service.spec.ts
@@ -113,6 +113,34 @@ describe('RoleService', () => {
     });
   });
 
+  describe('getHighestRole', () => {
+    it('Returns "Administrator" if userRoles has "Administrator"', () => {
+      service.userRoles = [roles.moderator, roles.admin, roles.user];
+      expect(service.getHighestRole()).toBe(roles.admin);
+
+      service.userRoles = [roles.admin, roles.user];
+      expect(service.getHighestRole()).toBe(roles.admin);
+    });
+
+    it('Returns "Moderator" if userRoles has "Moderator" and nothing higher', () => {
+      service.userRoles = [roles.user, roles.moderator];
+      expect(service.getHighestRole()).toBe(roles.moderator);
+
+      service.userRoles = [roles.moderator];
+      expect(service.getHighestRole()).toBe(roles.moderator);
+    });
+
+    it('Returns "User" if userRoles has "User" and nothing higher', () => {
+      service.userRoles = [roles.user];
+      expect(service.getHighestRole()).toBe(roles.user);
+    });
+
+    it('Returns null if userRoles is empty', () => {
+      service.userRoles = [];
+      expect(service.getHighestRole()).toBeNull();
+    });
+  });
+
   afterEach(() => {
     localStorage.clear();
   })

--- a/src/app/core/role-service/role.service.ts
+++ b/src/app/core/role-service/role.service.ts
@@ -63,4 +63,26 @@ export class RoleService {
 
     return localStorage.getItem('token') !== null;
   }
+
+  /**
+   * Returns the user's "highest" role. For example, if the user has the Administrator
+   * and Moderator roles, this method will return "Administrator". ``null`` is returned
+   * if the user is not logged in.
+   * @returns the user's highest role or ``null`` if the user is a guest
+   */
+  getHighestRole(): role | null {
+    if (this.isAdmin()) {
+      return roles.admin;
+    }
+
+    if (this.isModerator()) {
+      return roles.moderator;
+    }
+
+    if (this.isLoggedIn()) {
+      return roles.user;
+    }
+
+    return null;
+  }
 }

--- a/src/app/core/role-service/role.service.ts
+++ b/src/app/core/role-service/role.service.ts
@@ -36,4 +36,31 @@ export class RoleService {
   isGuest(): boolean {
     return this.userRoles.length === 0;
   }
+
+
+  /**
+   * Returns a boolean value that indicates whether the user is logged in or not.
+   * By default, the method determines that by checking if ``userRoles`` is empty
+   * or not.
+   * If you want this to be determined by whether the user has a JWT in the
+   * ``localStorage``, pass ``'localStorage'`` as an argument.
+   * 
+   * It's recommended to use the store strategy whenever possible.
+   * @returns a boolean value that indicates whether the user is logged in or not.
+   */
+  isLoggedIn(): boolean;
+  /**
+   * @param strategy how to determine if the user is logged it or not. ``store``
+   * will make the method check the ``userRoles`` (which is derived from the store).
+   * ``localStorage`` will make the method check if ``localStorage`` contains
+   * a ``token`` key. Using ``store`` is recommended whenever possible.
+   */
+  isLoggedIn(strategy: 'store' | 'localStorage'): boolean;
+  isLoggedIn(strategy: 'store' | 'localStorage' = 'store'): boolean {
+    if (strategy === 'store') {
+      return this.userRoles.length > 0;
+    }
+
+    return localStorage.getItem('token') !== null;
+  }
 }

--- a/src/app/core/role-service/role.service.ts
+++ b/src/app/core/role-service/role.service.ts
@@ -32,4 +32,8 @@ export class RoleService {
   isModerator(): boolean {
     return this.userRoles.includes(roles.moderator);
   }
+
+  isGuest(): boolean {
+    return this.userRoles.length === 0;
+  }
 }

--- a/src/app/core/role-service/role.service.ts
+++ b/src/app/core/role-service/role.service.ts
@@ -1,0 +1,26 @@
+import { Injectable } from '@angular/core';
+import { Store } from '@ngrx/store';
+import { IAppStore } from '../../../types/store/store.types';
+import { role } from '../../../types/auth/roles.types';
+import { selectUserRoles } from '../../store/user/user.selector';
+
+/**
+ * An injectable service to work with roles, such as verifying if the user
+ * has a certain role and what their highest role is.
+ * 
+ * When the service is initialized via the constructor, the user's roles are set in
+ * the ``userRoles`` property.
+ */
+@Injectable({
+  providedIn: 'root'
+})
+export class RoleService {
+
+  constructor(private readonly store: Store<IAppStore>) {
+    store.select(selectUserRoles).subscribe(roles => {
+      this.userRoles = roles;
+    });
+  }
+
+  userRoles: role[] = [];
+}

--- a/src/app/core/role-service/role.service.ts
+++ b/src/app/core/role-service/role.service.ts
@@ -28,4 +28,8 @@ export class RoleService {
   isAdmin(): boolean {
     return this.userRoles.includes(roles.admin);
   }
+
+  isModerator(): boolean {
+    return this.userRoles.includes(roles.moderator);
+  }
 }

--- a/src/app/core/role-service/role.service.ts
+++ b/src/app/core/role-service/role.service.ts
@@ -3,6 +3,7 @@ import { Store } from '@ngrx/store';
 import { IAppStore } from '../../../types/store/store.types';
 import { role } from '../../../types/auth/roles.types';
 import { selectUserRoles } from '../../store/user/user.selector';
+import { roles } from '../../constants/roles.constants';
 
 /**
  * An injectable service to work with roles, such as verifying if the user
@@ -23,4 +24,8 @@ export class RoleService {
   }
 
   userRoles: role[] = [];
+
+  isAdmin(): boolean {
+    return this.userRoles.includes(roles.admin);
+  }
 }

--- a/src/app/core/role-service/role.service.ts
+++ b/src/app/core/role-service/role.service.ts
@@ -25,18 +25,26 @@ export class RoleService {
 
   userRoles: role[] = [];
 
+  /**
+   * Returns a boolean value that indicates whether ``userRoles`` contains ``Administrator``.
+   */
   isAdmin(): boolean {
     return this.userRoles.includes(roles.admin);
   }
 
+  /**
+   * Returns a boolean value that indicates whether ``userRoles`` contains ``Moderator``.
+   */
   isModerator(): boolean {
     return this.userRoles.includes(roles.moderator);
   }
 
+  /**
+   * Returns a boolean value that indicates whether ``userRoles`` is empty.
+   */
   isGuest(): boolean {
     return this.userRoles.length === 0;
   }
-
 
   /**
    * Returns a boolean value that indicates whether the user is logged in or not.


### PR DESCRIPTION
This PR introduces the role service, which can be used to obtain information about the user's roles and their permissions. The following actions can be performed:
- checking whether the user is a guest, moderator, admin, or logged in.
- determining the user's role with the highest authority.

This PR also applies the role service to components that managed role permissions in any way.