### PR TITLE
add admin service

### DIFF
--- a/src/app/constants/api.constants.ts
+++ b/src/app/constants/api.constants.ts
@@ -43,6 +43,8 @@ export const api = {
       getModerators: `${administration}/moderators`,
       getAdmins: `${administration}/admins`,
       getUserByUsername: (username: string) => `${administration}/users/${username}`,
+      promoteToModerator: (id: number) => `${administration}/promote/${id}`,
+      demoteToUser: (id: number) => `${administration}/demote/${id}`,
     }
   }
 };

--- a/src/app/constants/api.constants.ts
+++ b/src/app/constants/api.constants.ts
@@ -45,6 +45,7 @@ export const api = {
       getUserByUsername: (username: string) => `${administration}/users/${username}`,
       promoteToModerator: (id: number) => `${administration}/promote/${id}`,
       demoteToUser: (id: number) => `${administration}/demote/${id}`,
+      logs: `${administration}/logs`,
     }
   }
 };

--- a/src/app/constants/api.constants.ts
+++ b/src/app/constants/api.constants.ts
@@ -4,6 +4,7 @@ const root = environment.api;
 const auth = `${root}/auth`;
 const quiz = `${root}/quiz`;
 const answer = `${root}/answers`;
+const administration = `${root}/administration`;
 
 export const api = {
   root,
@@ -37,6 +38,11 @@ export const api = {
     answers: {
       correctAnswersInstantMode: (questionId: number) => `${answer}/${questionId}/instant`,
       correctAnswersFull: (quizId: number) => `${answer}/${quizId}/full`,
+    },
+    administration: {
+      getModerators: `${administration}/moderators`,
+      getAdmins: `${administration}/admins`,
+      getUserByUsername: (username: string) => `${administration}/users/${username}`,
     }
   }
 };

--- a/src/app/features/admin-service/README.md
+++ b/src/app/features/admin-service/README.md
@@ -1,3 +1,9 @@
 # AdminService
 An injectable service that makes HTTP calls relating to administration,
 such as promoting and demoting users and obtaining logs.
+
+## Methods
+```typescript
+function getModerators(): Observable<IUser[]>
+```
+Sends a GET request to ``/administration/moderators`` and returns a list of all users that have the Moderator role (including administrators). Each user is listed with only one role, which is their highest one.

--- a/src/app/features/admin-service/README.md
+++ b/src/app/features/admin-service/README.md
@@ -21,3 +21,8 @@ function getUsersByUsername(username: string, page: number | string, order: orde
 Sends a GET request to ``/administration/users/{username}`` and returns a list of all users that contain the given ``username`` string. Each user is listed with their highest role. Optionally, you can pass a page to specify how the result should be paginated, and how the result will be ordered. The list is ordered based entirely on the username. The default options are page 1 and an ascending order.
 
 When passing page as a string, ensure that it is a numerical one.
+
+```typescript
+function promoteToModerator(id: number): Observable<IUser[]>
+```
+Sends a PUT request to ``/administration/promote/{id}``. In order for this request to work, the user must be of role ``user`` (and nothing else). The method returns an updated list of users.

--- a/src/app/features/admin-service/README.md
+++ b/src/app/features/admin-service/README.md
@@ -26,3 +26,8 @@ When passing page as a string, ensure that it is a numerical one.
 function promoteToModerator(id: number): Observable<IUser[]>
 ```
 Sends a PUT request to ``/administration/promote/{id}``. In order for this request to work, the user must be of role ``user`` (and nothing else). The method returns an updated list of users.
+
+```typescript
+function demoteToUser(id: number): Observable<IUser[]>
+```
+Sends a PUT request to ``/administration/demote/{id}``. In order for this request to work, the user must be of role ``moderator`` (and nothing higher). The method returns an updated list of users.

--- a/src/app/features/admin-service/README.md
+++ b/src/app/features/admin-service/README.md
@@ -1,6 +1,3 @@
 # AdminService
 An injectable service that makes HTTP calls relating to administration,
 such as promoting and demoting users and obtaining logs.
-
-Note that each method runs only if the role service's ``isAdmin``
-method returns true.

--- a/src/app/features/admin-service/README.md
+++ b/src/app/features/admin-service/README.md
@@ -1,0 +1,6 @@
+# AdminService
+An injectable service that makes HTTP calls relating to administration,
+such as promoting and demoting users and obtaining logs.
+
+Note that each method runs only if the role service's ``isAdmin``
+method returns true.

--- a/src/app/features/admin-service/README.md
+++ b/src/app/features/admin-service/README.md
@@ -7,3 +7,8 @@ such as promoting and demoting users and obtaining logs.
 function getModerators(): Observable<IUser[]>
 ```
 Sends a GET request to ``/administration/moderators`` and returns a list of all users that have the Moderator role (including administrators). Each user is listed with only one role, which is their highest one.
+
+```typescript
+function getAdmins(): Observable<IUser[]>
+```
+Sends a GET request to ``/administration/admins`` and returns a list of all users that have the Administrator role. Each user is listed with only one role, which is their highest one.

--- a/src/app/features/admin-service/README.md
+++ b/src/app/features/admin-service/README.md
@@ -31,3 +31,11 @@ Sends a PUT request to ``/administration/promote/{id}``. In order for this reque
 function demoteToUser(id: number): Observable<IUser[]>
 ```
 Sends a PUT request to ``/administration/demote/{id}``. In order for this request to work, the user must be of role ``moderator`` (and nothing higher). The method returns an updated list of users.
+
+
+```typescript
+function getActivityLogs(): Observable<ILogActivity[]>;
+function getActivityLogs(page: number | string): Observable<ILogActivity[]>;
+function getActivityLogs(page: number | string, order: order): Observable<ILogActivity[]>;
+```
+Returns a list of logs containing moderator/admin activities, such as promotions, demotions, editing/deleting of other people's quizzes and so on, sorted by the date. Arguments can be used to control the pagination and order of the results. The default options are page 1, sorted in an ascending order.

--- a/src/app/features/admin-service/README.md
+++ b/src/app/features/admin-service/README.md
@@ -12,3 +12,12 @@ Sends a GET request to ``/administration/moderators`` and returns a list of all 
 function getAdmins(): Observable<IUser[]>
 ```
 Sends a GET request to ``/administration/admins`` and returns a list of all users that have the Administrator role. Each user is listed with only one role, which is their highest one.
+
+```typescript
+function getUsersByUsername(username: string): Observable<IUser[]>;
+function getUsersByUsername(username: string, page: number | string): Observable<IUser[]>;
+function getUsersByUsername(username: string, page: number | string, order: order): Observable<IUser[]>;
+```
+Sends a GET request to ``/administration/users/{username}`` and returns a list of all users that contain the given ``username`` string. Each user is listed with their highest role. Optionally, you can pass a page to specify how the result should be paginated, and how the result will be ordered. The list is ordered based entirely on the username. The default options are page 1 and an ascending order.
+
+When passing page as a string, ensure that it is a numerical one.

--- a/src/app/features/admin-service/admin.service.spec.ts
+++ b/src/app/features/admin-service/admin.service.spec.ts
@@ -1,0 +1,20 @@
+import { TestBed } from '@angular/core/testing';
+
+import { AdminService } from './admin.service';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { AppStoreModule } from '../../store/app-store.module';
+
+describe('AdminService', () => {
+  let service: AdminService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule, AppStoreModule]
+    });
+    service = TestBed.inject(AdminService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/features/admin-service/admin.service.spec.ts
+++ b/src/app/features/admin-service/admin.service.spec.ts
@@ -6,6 +6,7 @@ import { AppStoreModule } from '../../store/app-store.module';
 import { IUser, IUserResponse } from '../../../types/responses/administration.types';
 import { roles } from '../../constants/roles.constants';
 import { HttpStatusCode } from '@angular/common/http';
+import { ILogActivity } from '../../../types/administration/logs.types';
 
 describe('AdminService', () => {
   let service: AdminService;
@@ -80,7 +81,7 @@ describe('AdminService', () => {
           username: 'a',
           roles: [roles.moderator, roles.user, roles.admin],
         },
-       
+
       ] as IUserResponse[], {
         status: HttpStatusCode.Ok,
         statusText: 'Ok'
@@ -116,10 +117,10 @@ describe('AdminService', () => {
           roles: [roles.user, roles.moderator],
         },
       ] as IUserResponse[],
-      {
-        status: HttpStatusCode.Ok,
-        statusText: 'Ok',
-      }
+        {
+          status: HttpStatusCode.Ok,
+          statusText: 'Ok',
+        }
       );
     });
 
@@ -155,10 +156,10 @@ describe('AdminService', () => {
           roles: [roles.user, roles.moderator],
         },
       ] as IUserResponse[],
-      {
-        status: HttpStatusCode.Ok,
-        statusText: 'Ok',
-      }
+        {
+          status: HttpStatusCode.Ok,
+          statusText: 'Ok',
+        }
       );
     });
   });
@@ -186,7 +187,7 @@ describe('AdminService', () => {
           username: 'a',
           roles: [roles.moderator, roles.user, roles.admin],
         },
-       
+
       ] as IUserResponse[], {
         status: HttpStatusCode.Ok,
         statusText: 'Ok'
@@ -209,7 +210,7 @@ describe('AdminService', () => {
           console.warn(err);
         },
       });
-      
+
       const request = testController.expectOne(service.url.demoteToUser(1));
       request.flush([
         {
@@ -217,10 +218,65 @@ describe('AdminService', () => {
           username: 'a',
           roles: [roles.user],
         },
-       
+
       ] as IUserResponse[], {
         status: HttpStatusCode.Ok,
         statusText: 'Ok'
+      });
+    });
+  });
+
+  describe('getActivityLogs', () => {
+    it('Retrieves a list of logs', (done: DoneFn) => {
+      service.getActivityLogs().subscribe({
+        next: res => {
+          expect(res.length).toBe(1);
+          expect(res[0].message).toBe('a');
+          done();
+        },
+        error: err => {
+          console.warn(err);
+          done.fail('Expected a successful response, not an error one');
+        },
+      });
+
+      const request = testController.expectOne(service.url.logs);
+      request.flush(
+        [
+          {
+            message: 'a',
+          },
+        ] as ILogActivity[],
+        {
+          status: HttpStatusCode.Ok,
+          statusText: 'Ok',
+        },
+      );
+    });
+
+    it('Attaches query parameters successfully', (done: DoneFn) => {
+      service.getActivityLogs(2, 'desc').subscribe({
+        next: res => {
+          expect(res).toBeTruthy();
+          done();
+        },
+        error: err => {
+          console.warn(err);
+          done.fail('Expected a successful response, not an error one');
+        },
+      });
+
+      const request = testController.expectOne(req => {
+        const params = req.params;
+        const page = params.get('page');
+        const order = params.get('order');
+
+        return page === '2' && order === 'desc';
+      });
+
+      request.flush([], {
+        status: HttpStatusCode.Ok,
+        statusText: 'Ok',
       });
     });
   });

--- a/src/app/features/admin-service/admin.service.spec.ts
+++ b/src/app/features/admin-service/admin.service.spec.ts
@@ -58,6 +58,36 @@ describe('AdminService', () => {
     });
   });
 
+  describe('getAdmins', () => {
+    it('Returns an array of users and maps all roles to the highest one', (done: DoneFn) => {
+      service.getAdmins().subscribe({
+        next: res => {
+          expect(res.length).toBe(1);
+          expect(res[0].id).toBe(1);
+          expect(res[0].role).toBe(roles.admin);
+
+          done();
+        },
+        error: err => {
+          done.fail('Expected a successful response, not an error one');
+          console.warn(err);
+        }
+      })
+      const request = testController.expectOne(service.url.getAdmins);
+      request.flush([
+        {
+          id: 1,
+          username: 'a',
+          roles: [roles.moderator, roles.user, roles.admin],
+        },
+       
+      ] as IUserResponse[], {
+        status: HttpStatusCode.Ok,
+        statusText: 'Ok'
+      })
+    });
+  });
+
   afterEach(() => {
     testController.verify();
   });

--- a/src/app/features/admin-service/admin.service.spec.ts
+++ b/src/app/features/admin-service/admin.service.spec.ts
@@ -1,20 +1,64 @@
 import { TestBed } from '@angular/core/testing';
 
 import { AdminService } from './admin.service';
-import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 import { AppStoreModule } from '../../store/app-store.module';
+import { IUser, IUserResponse } from '../../../types/responses/administration.types';
+import { roles } from '../../constants/roles.constants';
+import { HttpStatusCode } from '@angular/common/http';
 
 describe('AdminService', () => {
   let service: AdminService;
+  let testController: HttpTestingController;
 
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [HttpClientTestingModule, AppStoreModule]
     });
     service = TestBed.inject(AdminService);
+    testController = TestBed.inject(HttpTestingController);
   });
 
   it('should be created', () => {
     expect(service).toBeTruthy();
+  });
+
+  describe('getModerators', () => {
+    it('Returns an array of users and maps all roles to the highest one', (done: DoneFn) => {
+      service.getModerators().subscribe({
+        next: res => {
+          expect(res.length).toBe(2);
+          expect(res[0].id).toBe(1);
+          expect(res[0].role).toBe(roles.moderator);
+
+          expect(res[1].role).toBe(roles.admin);
+          done();
+        },
+        error: err => {
+          done.fail('Expected a successful response, not an error one');
+          console.warn(err);
+        }
+      })
+      const request = testController.expectOne(service.url.getModerators);
+      request.flush([
+        {
+          id: 1,
+          username: 'a',
+          roles: [roles.moderator, roles.user],
+        },
+        {
+          id: 2,
+          username: 'b',
+          roles: [roles.moderator, roles.user, roles.admin]
+        }
+      ] as IUserResponse[], {
+        status: HttpStatusCode.Ok,
+        statusText: 'Ok'
+      })
+    });
+  });
+
+  afterEach(() => {
+    testController.verify();
   });
 });

--- a/src/app/features/admin-service/admin.service.spec.ts
+++ b/src/app/features/admin-service/admin.service.spec.ts
@@ -71,7 +71,7 @@ describe('AdminService', () => {
         error: err => {
           done.fail('Expected a successful response, not an error one');
           console.warn(err);
-        }
+        },
       })
       const request = testController.expectOne(service.url.getAdmins);
       request.flush([
@@ -84,7 +84,7 @@ describe('AdminService', () => {
       ] as IUserResponse[], {
         status: HttpStatusCode.Ok,
         statusText: 'Ok'
-      })
+      });
     });
   });
 
@@ -160,6 +160,37 @@ describe('AdminService', () => {
         statusText: 'Ok',
       }
       );
+    });
+  });
+
+  describe('promoteToModerator', () => {
+    it('Returns a list of users successfully', (done: DoneFn) => {
+      service.promoteToModerator(1).subscribe({
+        next: res => {
+          expect(res.length).toBe(1);
+          expect(res[0].id).toBe(1);
+          expect(res[0].role).toBe(roles.admin);
+
+          done();
+        },
+        error: err => {
+          done.fail('Expected a successful response, not an error one');
+          console.warn(err);
+        },
+      });
+      
+      const request = testController.expectOne(service.url.promoteToModerator(1));
+      request.flush([
+        {
+          id: 1,
+          username: 'a',
+          roles: [roles.moderator, roles.user, roles.admin],
+        },
+       
+      ] as IUserResponse[], {
+        status: HttpStatusCode.Ok,
+        statusText: 'Ok'
+      });
     });
   });
 

--- a/src/app/features/admin-service/admin.service.spec.ts
+++ b/src/app/features/admin-service/admin.service.spec.ts
@@ -178,13 +178,44 @@ describe('AdminService', () => {
           console.warn(err);
         },
       });
-      
+
       const request = testController.expectOne(service.url.promoteToModerator(1));
       request.flush([
         {
           id: 1,
           username: 'a',
           roles: [roles.moderator, roles.user, roles.admin],
+        },
+       
+      ] as IUserResponse[], {
+        status: HttpStatusCode.Ok,
+        statusText: 'Ok'
+      });
+    });
+  });
+
+  describe('demoteToUser', () => {
+    it('Returns a list of users successfully', (done: DoneFn) => {
+      service.demoteToUser(1).subscribe({
+        next: res => {
+          expect(res.length).toBe(1);
+          expect(res[0].id).toBe(1);
+          expect(res[0].role).toBe(roles.user);
+
+          done();
+        },
+        error: err => {
+          done.fail('Expected a successful response, not an error one');
+          console.warn(err);
+        },
+      });
+      
+      const request = testController.expectOne(service.url.demoteToUser(1));
+      request.flush([
+        {
+          id: 1,
+          username: 'a',
+          roles: [roles.user],
         },
        
       ] as IUserResponse[], {

--- a/src/app/features/admin-service/admin.service.ts
+++ b/src/app/features/admin-service/admin.service.ts
@@ -1,4 +1,4 @@
-import { HttpClient } from '@angular/common/http';
+import { HttpClient, HttpParams } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { RoleService } from '../../core/role-service/role.service';
 import { Observable, map } from 'rxjs';
@@ -6,6 +6,7 @@ import { IUser, IUserResponse } from '../../../types/responses/administration.ty
 import { api } from '../../constants/api.constants';
 import { role } from '../../../types/auth/roles.types';
 import { roles } from '../../constants/roles.constants';
+import { order } from '../../../types/others/lists.types';
 
 /**
  * An injectable service that makes HTTP calls relating to administration,
@@ -20,7 +21,7 @@ export class AdminService {
     private readonly http: HttpClient,
     private readonly roleService: RoleService,
   ) { }
-  
+
   url = api.endpoints.administration;
 
   /**
@@ -31,9 +32,9 @@ export class AdminService {
    */
   getModerators(): Observable<IUser[]> {
     return this.http.get<IUserResponse[]>(this.url.getModerators)
-    .pipe(
-      map(users => users.map(this.mapUserToHighestRole))
-    );
+      .pipe(
+        map(users => users.map(this.mapUserToHighestRole))
+      );
   }
 
   /**
@@ -44,9 +45,61 @@ export class AdminService {
    */
   getAdmins(): Observable<IUser[]> {
     return this.http.get<IUserResponse[]>(this.url.getAdmins)
-    .pipe(
-      map(users => users.map(this.mapUserToHighestRole))
-    );
+      .pipe(
+        map(users => users.map(this.mapUserToHighestRole))
+      );
+  }
+
+  /**
+   * Sends a GET request to ``/administration/users/{username}`` and returns a list
+   * of all users that contain the given ``username`` string. Each user is listed
+   * with their highest role.
+   * @param username the string by which the database will look for users.
+   * @returns the first page of users, ordered by their usernames in an ascending order.
+   */
+  getUsersByUsername(username: string): Observable<IUser[]>;
+  /**
+   * Sends a GET request to ``/administration/users/{username}`` and returns a list
+   * of all users that contain the given ``username`` string. Each user is listed
+   * with their highest role. 
+   * @param username the string by which the database will look for users.
+   * @param page the page for the query. When passed as string, ensure that it is a
+   * numerical one.
+   * @returns a list of users for the given page, ordered by their usernames in 
+   * an ascending order
+   */
+  getUsersByUsername(username: string, page: number | string): Observable<IUser[]>;
+  /**
+   * Sends a GET request to ``/administration/users/{username}`` and returns a list
+   * of all users that contain the given ``username`` string. Each user is listed
+   * with their highest role. 
+   * @param username the string by which the database will look for users.
+   * @param page the page for the query. When passed as string, ensure that it is a
+   * numerical one.
+   * @param order the order by which the users will be listed, based on their username.
+   * @returns a list of users for the given page, ordered by their usernames in 
+   * the specified order.
+   */
+  getUsersByUsername(username: string, page: number | string, order: order): Observable<IUser[]>;
+  getUsersByUsername(username: string, page?: number | string, order?: order): Observable<IUser[]> {
+    let params = new HttpParams();
+    if (page) {
+      params = params.append('page', page);
+    }
+
+    if (order) {
+      params = params.append('order', order);
+    }
+
+    const request = this.http
+      .get<IUserResponse[]>(this.url.getUserByUsername(username), {
+        params
+      })
+      .pipe(
+        map(users => users.map(this.mapUserToHighestRole))
+      );
+
+    return request;
   }
 
   private mapUserToHighestRole(user: IUserResponse): IUser {

--- a/src/app/features/admin-service/admin.service.ts
+++ b/src/app/features/admin-service/admin.service.ts
@@ -116,6 +116,20 @@ export class AdminService {
     );
   }
 
+  /**
+   * Sends a PUT request to ``/administration/demote/{id}``. In order for this
+   * request to work, the user must be of role ``moderator``.
+   * @param id the ID of the moderator to be demoted to user.
+   * @returns an Observable of type ``IUser[]``. You can use this to update
+   * the list of users after the response resolves.
+   */
+  demoteToUser(id: number): Observable<IUser[]> {
+    return this.http.put<IUserResponse[]>(this.url.demoteToUser(id), {})
+    .pipe(
+      map(users => users.map(this.mapUserToHighestRole))
+    );
+  }
+
   private mapUserToHighestRole(user: IUserResponse): IUser {
     const { id, username } = user;
     if (user.roles.includes(roles.admin)) {

--- a/src/app/features/admin-service/admin.service.ts
+++ b/src/app/features/admin-service/admin.service.ts
@@ -102,6 +102,20 @@ export class AdminService {
     return request;
   }
 
+  /**
+   * Sends a PUT request to ``/administration/promote/{id}``. In order for this
+   * request to work, the user must be of role ``user``.
+   * @param id the ID of the user to be promoted to a Moderator
+   * @returns an Observable of type ``IUser[]``. You can use this to update
+   * the list of users after the response resolves.
+   */
+  promoteToModerator(id: number): Observable<IUser[]> {
+    return this.http.put<IUserResponse[]>(this.url.promoteToModerator(id), {})
+    .pipe(
+      map(users => users.map(this.mapUserToHighestRole))
+    );
+  }
+
   private mapUserToHighestRole(user: IUserResponse): IUser {
     const { id, username } = user;
     if (user.roles.includes(roles.admin)) {

--- a/src/app/features/admin-service/admin.service.ts
+++ b/src/app/features/admin-service/admin.service.ts
@@ -36,6 +36,19 @@ export class AdminService {
     );
   }
 
+  /**
+   * Sends a GET request to ``/administration/admins`` and returns a list
+   * of all users that have the Administrator role.
+   * Each user is listed with only one role, which is their highest one.
+   * @returns an Observable that resolves to an array of ``IUser``.
+   */
+  getAdmins(): Observable<IUser[]> {
+    return this.http.get<IUserResponse[]>(this.url.getAdmins)
+    .pipe(
+      map(users => users.map(this.mapUserToHighestRole))
+    );
+  }
+
   private mapUserToHighestRole(user: IUserResponse): IUser {
     const { id, username } = user;
     if (user.roles.includes(roles.admin)) {

--- a/src/app/features/admin-service/admin.service.ts
+++ b/src/app/features/admin-service/admin.service.ts
@@ -1,0 +1,23 @@
+import { HttpClient } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { RoleService } from '../../core/role-service/role.service';
+
+/**
+ * An injectable service that makes HTTP calls relating to administration,
+ * such as promoting and demoting users and obtaining logs.
+ * 
+ * Note that each method runs only if the role service's ``isAdmin``
+ * method returns true.
+ */
+@Injectable({
+  providedIn: 'root'
+})
+export class AdminService {
+
+  constructor(
+    private readonly http: HttpClient,
+    private readonly roleService: RoleService,
+  ) { }
+
+
+}

--- a/src/app/features/admin-service/admin.service.ts
+++ b/src/app/features/admin-service/admin.service.ts
@@ -6,7 +6,8 @@ import { IUser, IUserResponse } from '../../../types/responses/administration.ty
 import { api } from '../../constants/api.constants';
 import { role } from '../../../types/auth/roles.types';
 import { roles } from '../../constants/roles.constants';
-import { order } from '../../../types/others/lists.types';
+import { order, sort } from '../../../types/others/lists.types';
+import { ILogActivity } from '../../../types/administration/logs.types';
 
 /**
  * An injectable service that makes HTTP calls relating to administration,
@@ -128,6 +129,38 @@ export class AdminService {
     .pipe(
       map(users => users.map(this.mapUserToHighestRole))
     );
+  }
+
+  /**
+   * Retrieves a list of moderator and admin activities.
+   * 
+   * @returns a list of log activities on page 1, sorted by title in an ascending order.
+   */
+  getActivityLogs(): Observable<ILogActivity[]>;
+  /**
+   * Retrieves a list of moderator and admin activities.
+   * @param page the page of the query
+   * @returns a list of log activities on the specified page, sorted by date in an ascending order.
+   */
+  getActivityLogs(page: number | string): Observable<ILogActivity[]>;
+  /**
+   * Retrieves a list of moderator and admin activities.
+   * @param page the page of the query
+   * @param order the order by which the result will be sorted.
+   * @returns a list of log activities on the specified page, sorted by date in the specified order.
+   */
+  getActivityLogs(page: number | string, order: order): Observable<ILogActivity[]>;
+  getActivityLogs(page?: number | string, order?: order): Observable<ILogActivity[]> {
+    let params = new HttpParams();
+    if (page) {
+      params = params.append('page', page);
+    }
+
+    if (order) {
+      params = params.append('order', order);
+    }
+
+    return this.http.get<ILogActivity[]>(this.url.logs, { params });
   }
 
   private mapUserToHighestRole(user: IUserResponse): IUser {

--- a/src/app/features/admin-service/admin.service.ts
+++ b/src/app/features/admin-service/admin.service.ts
@@ -1,13 +1,15 @@
 import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { RoleService } from '../../core/role-service/role.service';
+import { Observable, map } from 'rxjs';
+import { IUser, IUserResponse } from '../../../types/responses/administration.types';
+import { api } from '../../constants/api.constants';
+import { role } from '../../../types/auth/roles.types';
+import { roles } from '../../constants/roles.constants';
 
 /**
  * An injectable service that makes HTTP calls relating to administration,
  * such as promoting and demoting users and obtaining logs.
- * 
- * Note that each method runs only if the role service's ``isAdmin``
- * method returns true.
  */
 @Injectable({
   providedIn: 'root'
@@ -18,6 +20,36 @@ export class AdminService {
     private readonly http: HttpClient,
     private readonly roleService: RoleService,
   ) { }
+  
+  url = api.endpoints.administration;
 
+  /**
+   * Sends a GET request to ``/administration/moderators`` and returns a list
+   * of all users that have the Moderator role (including administrators).
+   * Each user is listed with only one role, which is their highest one.
+   * @returns an Observable that resolves to an array of ``IUser``.
+   */
+  getModerators(): Observable<IUser[]> {
+    return this.http.get<IUserResponse[]>(this.url.getModerators)
+    .pipe(
+      map(users => users.map(this.mapUserToHighestRole))
+    );
+  }
 
+  private mapUserToHighestRole(user: IUserResponse): IUser {
+    const { id, username } = user;
+    if (user.roles.includes(roles.admin)) {
+      return { id, username, role: roles.admin, };
+    }
+
+    if (user.roles.includes(roles.moderator)) {
+      return { id, username, role: roles.moderator, };
+    }
+
+    if (user.roles.includes(roles.user)) {
+      return { id, username, role: roles.user, };
+    }
+
+    throw new Error('User does not have any of the valid roles');
+  }
 }

--- a/src/types/administration/logs.types.ts
+++ b/src/types/administration/logs.types.ts
@@ -1,0 +1,3 @@
+export interface ILogActivity {
+  message: string;
+}

--- a/src/types/others/lists.types.ts
+++ b/src/types/others/lists.types.ts
@@ -1,0 +1,2 @@
+export type order = 'asc' | 'desc';
+export type sort = 'title' | 'createdOn' | 'updatedOn';

--- a/src/types/responses/administration.types.ts
+++ b/src/types/responses/administration.types.ts
@@ -1,0 +1,13 @@
+import { role } from '../auth/roles.types';
+
+export interface IUser {
+  username: string;
+  id: number;
+  role: role,
+}
+
+export interface IUserResponse {
+  username: string;
+  id: number;
+  roles: role[],
+}


### PR DESCRIPTION
this PR introduces the admin service, which allows you to perform administrative tasks such as:
- promoting users to moderators
- demoting moderators back to users
- getting a list of moderators and admins
- getting a list of users by a username
- getting activity logs that describe some of the actions above + editing/deleting other people's quizzes

note that there is no public API for promoting users to administrators and demoting administrators to a lower role. The administrator can only be seeded through the server.

**planned features for the future:**
insert pagination in promotions and demotions so that the updated list accurately reflects the state of the page.