### PR TITLE
Implement a shared layout for catalogue pages

### DIFF
--- a/src/app/features/quiz-lists/all-quizzes/README.md
+++ b/src/app/features/quiz-lists/all-quizzes/README.md
@@ -1,0 +1,20 @@
+# app-all-quizzes-component
+
+## Usage
+```html
+<app-all-quizzes></app-all-quizzes>
+```
+
+Renders an ``<app-catalogue>`` component which will display quizzes from the entire catalogue of quizzes. The initial quizzes are taken from the route's resolved data, which will be supplied in the property ``catalogue``.
+
+## Methods
+```typescript
+function getResolvedData(): Observable<Data>
+```
+Returns the resolved data from the activated route's ``data``. This method is used to facilitate testing / mocking.
+
+```typescript
+function updateQuizzes({ page, sort, order }: { page: number, sort: sort, order: order } ): void
+```
+Fetches a list of quizzes from ``/quiz/all``, passing the provided parameters as query strings to the request, and updates the ``catalogue`` property in a subscription.
+

--- a/src/app/features/quiz-lists/all-quizzes/all-quizzes.component.html
+++ b/src/app/features/quiz-lists/all-quizzes/all-quizzes.component.html
@@ -1,8 +1,2 @@
 <h1>All quizzes</h1>
-<app-catalogue-select-menu [selectedValue]="sortOrder"
-  (selectEvent)="changeSortAndOrder($event)"></app-catalogue-select-menu>
-
-
-<app-quiz-list-item *ngFor="let quiz of catalogue.quizzes" [quiz]="quiz"></app-quiz-list-item>
-
-<app-catalogue-paginator [total]="catalogue.total" [page]="page" (pageEvent)="changePage($event)"></app-catalogue-paginator>
+<app-catalogue [catalogue]="catalogue" (updateQuizzesEvent)="updateQuizzes($event)"></app-catalogue>

--- a/src/app/features/quiz-lists/all-quizzes/all-quizzes.module.ts
+++ b/src/app/features/quiz-lists/all-quizzes/all-quizzes.module.ts
@@ -1,7 +1,6 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { AllQuizzesComponent } from './all-quizzes.component';
-import { SharedModule } from '../../../shared/shared.module';
 
 @NgModule({
   declarations: [],

--- a/src/app/shared/catalogue/README.md
+++ b/src/app/shared/catalogue/README.md
@@ -1,0 +1,30 @@
+# app-catalogue
+
+## Usage
+```html
+<app-catalogue [catalogue]="catalogue"></app-catalogue>
+```
+
+### @Input() properties
+* ``catalogue`` - an object of type ``IQuizList``. The component will use the data inside it to render the quizzes and the correct page. (**Required**)
+
+### @Output() properties
+* ``updateQuizzesEvent`` - this event is emitted every time the user changes the page or selects a new sorting category / order. The event passes an object containing the requested page, sort category, and order.
+
+Renders an ``app-catalogue-select-menu``, a list of ``app-quiz-list-item`` elements that reflect the ``catalogue``'s ``quizzes`` property, and an ``app-catalogue-paginator``. Upon load, the component will set the page and menu to the appropriate options based on the URL's query strings, if there are such.
+
+## Methods
+```typescript
+function getQueryString(query: string): string | null
+```
+Returns the value of the given ``query`` from the URL or ``null`` if the query is missing.
+
+```typescript
+function changeSortAndOrder(value: ISort): void
+```
+Updates the ``sort`` and ``order`` properties to the passed ``value``'s respective properties and updates the URL's query strings to reflect that. In addition, this method will emit, ``updateQuizzesEvent`` passing the current page and the new values as arguments.
+
+```typescript
+function changePage(page: number): void
+```
+Updates the ``page`` property to the passed argument and updates the URL's query strings to reflect that. In addition, this method will emit, ``updateQuizzesEvent`` passing the new page and the current sorting options as arguments.

--- a/src/app/shared/catalogue/catalogue.component.html
+++ b/src/app/shared/catalogue/catalogue.component.html
@@ -1,0 +1,6 @@
+<app-catalogue-select-menu [selectedValue]="sortOrder"
+  (selectEvent)="changeSortAndOrder($event)"></app-catalogue-select-menu>
+
+<app-quiz-list-item *ngFor="let quiz of catalogue.quizzes" [quiz]="quiz"></app-quiz-list-item>
+
+<app-catalogue-paginator [total]="catalogue.total" [page]="page" (pageEvent)="changePage($event)"></app-catalogue-paginator>

--- a/src/app/shared/catalogue/catalogue.component.spec.ts
+++ b/src/app/shared/catalogue/catalogue.component.spec.ts
@@ -1,0 +1,267 @@
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+
+import { CatalogueComponent } from './catalogue.component';
+import { AppStoreModule } from '../../store/app-store.module';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { MatPaginatorHarness } from '@angular/material/paginator/testing';
+import { HarnessLoader } from '@angular/cdk/testing';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { RouterModule } from '@angular/router';
+import { QuizService } from '../../features/quiz-service/quiz.service';
+import { Observable, of } from 'rxjs';
+import { IQuizList, IQuizListItem } from '../../../types/others/lists.types';
+import { Location } from '@angular/common';
+import { MatSelectHarness } from '@angular/material/select/testing';
+
+function generateQuizzes(n: number, reverse = false): IQuizList {
+  const quizzes: IQuizListItem[] = [];
+  for (let i = 0; i < n; i++) {
+    quizzes.push(
+      {
+        id: i,
+        title: `${i}`,
+        description: 'wewehwehwe',
+        createdOn: Date.now().toString(),
+        updatedOn: Date.now().toString(),
+        instantMode: true,
+      }
+    );
+  }
+
+  if (reverse) {
+    quizzes.reverse();
+  }
+  
+  return {
+    total: 10,
+    quizzes,
+  };
+}
+
+describe('CatalogueComponent', () => {
+  let component: CatalogueComponent;
+  let fixture: ComponentFixture<CatalogueComponent>;
+
+  let location: Location;
+  let loader: HarnessLoader;
+
+  let element: HTMLElement;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        CatalogueComponent,
+        AppStoreModule,
+        RouterModule.forRoot([
+          {
+            path: '',
+            component: CatalogueComponent,
+          },
+          {
+            path: 'test',
+            component: CatalogueComponent,
+            data: {
+              catalogue: generateQuizzes(7)
+            }
+          }
+        ]),
+        NoopAnimationsModule,
+        HttpClientTestingModule,
+      ],
+
+    });
+
+    fixture = TestBed.createComponent(CatalogueComponent);
+    location = TestBed.inject(Location);
+
+    loader = TestbedHarnessEnvironment.loader(fixture);
+
+    component = fixture.componentInstance;
+    
+    element = fixture.debugElement.nativeElement as HTMLElement;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  describe('Unit tests', () => {
+    describe('ngOnInit', () => {
+      it('Sets all relevant properties based on query parameters', () => {
+        spyOn(component, 'getQueryString')
+          .withArgs('page')
+          .and.returnValue('121')
+          .withArgs('sort')
+          .and.returnValue('createdOn')
+          .withArgs('order')
+          .and.returnValue('desc');
+
+        component.ngOnInit();
+
+        expect(component.page).toBe(121);
+        expect(component.sort).toBe('createdOn');
+        expect(component.order).toBe('desc');
+      });
+
+      it('Sets all relevant properties from query parameters to default values if the query params are missing', () => {
+        spyOn(component, 'getQueryString')
+          .withArgs('page')
+          .and.returnValue(null)
+          .withArgs('sort')
+          .and.returnValue(null)
+          .withArgs('order')
+          .and.returnValue(null);
+
+        component.ngOnInit();
+
+        expect(component.page).toBe(1);
+        expect(component.sort).toBe('title');
+        expect(component.order).toBe('asc');
+      });
+    });
+
+    describe('changePage', () => {
+      it('Sets the page property when called', () => {
+        spyOn(location, 'replaceState').and.stub();
+        spyOn(component.updateQuizzesEvent, 'emit');
+
+        component.changePage(2);
+        
+        expect(component.updateQuizzesEvent.emit).toHaveBeenCalledWith(
+          { page: 2, sort: 'title', order: 'asc' }
+        );
+
+        expect(component.page).toBe(2);
+        expect(location.replaceState).toHaveBeenCalled();
+      });
+    });
+
+    describe('changeSortAndOrder', () => {
+      it('Changes the sort and order properties when called', () => {
+        spyOn(location, 'replaceState').and.stub();
+        spyOn(component.updateQuizzesEvent, 'emit');
+        component.changeSortAndOrder({ sort: 'createdOn', order: 'desc' });
+
+        expect(component.sort).toBe('createdOn');
+        expect(component.order).toBe('desc');
+
+        expect(location.replaceState).toHaveBeenCalled();
+        expect(component.updateQuizzesEvent.emit).toHaveBeenCalledWith(
+          { page: 1, sort: 'createdOn', order: 'desc' }
+        );
+      });
+    });
+  });
+
+  describe('Component tests', () => {
+    describe('component initilization', () => {
+      it('Sets paginator to correct page based on query string', waitForAsync(async () => {
+        const paginators = await loader.getAllHarnesses(MatPaginatorHarness);
+        const paginator = paginators[0];
+
+        spyOn(component, 'getQueryString')
+          .withArgs('page')
+          .and.returnValue('3')
+          .withArgs('sort')
+          .and.returnValue(null)
+          .withArgs('order')
+          .and.returnValue(null);
+
+        component.ngOnInit();
+        fixture.detectChanges();
+
+        component.catalogue.total = 100;
+        fixture.detectChanges();
+
+        await paginator.goToNextPage();
+
+        expect(component.page).toBe(4);
+      }));
+
+      it('Sets the select menu to the correct option based on query string', waitForAsync(async () => {
+        const selectMenus = await loader.getAllHarnesses(MatSelectHarness);
+        const menu = selectMenus[0];
+
+        spyOn(component, 'getQueryString')
+          .withArgs('page')
+          .and.returnValue('3')
+          .withArgs('sort')
+          .and.returnValue('createdOn')
+          .withArgs('order')
+          .and.returnValue('desc');
+
+        component.ngOnInit();
+        fixture.detectChanges();
+
+        await fixture.whenStable();
+
+        await menu.open();
+        fixture.detectChanges()
+        const value = await menu.getValueText();
+        fixture.detectChanges();
+        expect(value).toBe('Date of creation (Descending)');
+      }));
+
+      it('Populates the page with quizzes from Input property', waitForAsync(async () => {
+        component.catalogue = generateQuizzes(7);
+        component.ngOnInit();
+        fixture.detectChanges();
+
+        await fixture.whenStable();
+
+        const items = element.querySelectorAll('.quiz-list-item');
+        expect(items.length).toBe(7);
+
+        component.catalogue = generateQuizzes(3);
+        fixture.detectChanges();
+
+        const items2 = element.querySelectorAll('.quiz-list-item');
+        expect(items2.length).toBe(3);
+      }));
+    });
+
+    describe('interaction', () => {
+      it('Changes location path when a new page is selected', waitForAsync(async () => {
+        component.catalogue = generateQuizzes(7);
+        const paginators = await loader.getAllHarnesses(MatPaginatorHarness);
+        const paginator = paginators[0];
+
+        component.ngOnInit();
+        fixture.detectChanges();
+
+        await paginator.goToNextPage();
+        fixture.detectChanges();
+
+        await fixture.whenStable();
+        console.log(element);
+        
+        const path = location.path();
+        expect(path.includes('page=2')).toBeTrue();
+      }));
+
+      it('Changes location path when a new option is chosen', waitForAsync(async () => {
+        component.catalogue = generateQuizzes(7);
+        const menu = await loader.getHarness(MatSelectHarness);
+
+        component.ngOnInit();
+        fixture.detectChanges();
+
+        await menu.open();
+        fixture.detectChanges();
+
+        const options = await menu.getOptions();
+        await options[1].click();
+        fixture.detectChanges();
+
+        const path = location.path();
+        
+        expect(path.includes('sort=title')).toBeTrue();
+        expect(path.includes('order=desc')).toBeTrue();
+
+      }));
+    });
+  });
+});

--- a/src/app/shared/catalogue/catalogue.component.ts
+++ b/src/app/shared/catalogue/catalogue.component.ts
@@ -1,0 +1,112 @@
+import { Component, EventEmitter, Input, OnDestroy, OnInit, Output } from '@angular/core';
+import { CommonModule, Location } from '@angular/common';
+import { IQuizList, order, sort } from '../../../types/others/lists.types';
+import { HttpParams } from '@angular/common/http';
+import { ISort } from '../../../types/components/catalogue-select-menu.types';
+import { CataloguePaginatorModule } from '../catalogue-paginator/catalogue-paginator.module';
+import { CatalogueSelectMenuComponent } from '../catalogue-select-menu/catalogue-select-menu.component';
+import { QuizListItemComponent } from '../quiz-list-item/quiz-list-item.component';
+@Component({
+  selector: 'app-catalogue',
+  standalone: true,
+  imports: [
+    CommonModule,
+    CataloguePaginatorModule,
+    CatalogueSelectMenuComponent,
+    QuizListItemComponent,
+  ],
+  templateUrl: './catalogue.component.html',
+  styleUrls: ['./catalogue.component.scss']
+})
+export class CatalogueComponent implements OnInit {
+  constructor(
+    private readonly location: Location,
+  ) { }
+
+  @Output() updateQuizzesEvent = new EventEmitter<
+    {
+      page: number,
+      sort: sort,
+      order: order,
+    }
+  >
+
+  ngOnInit(): void {
+    this.page = Number(this.getQueryString('page')) || 1;
+    this.sort = this.getQueryString('sort') as sort || 'title';
+    this.order = this.getQueryString('order') as order || 'asc';
+  }
+
+  /**
+   * Returns the given query string from the URL.
+   * @param query 
+   * @returns the query string or null if the query string is absent from the URL.
+   */
+  getQueryString(query: string): string | null {
+    const url: URL = new URL(window.top?.location.href || '');
+    const params: URLSearchParams = url.searchParams;
+    return params.get(query);
+  }
+
+  @Input({ required: true }) catalogue: IQuizList = {
+    total: 0,
+    quizzes: [],
+  };
+
+  page = 0;
+  sort: sort = 'title';
+  order: order = 'asc';
+
+  protected get sortOrder() { return `${this.sort}-${this.order}` }
+
+  /**
+   * *Updates the ``sort`` and ``order`` properties with the input, 
+   * the URL's string queries, and the catalogue with
+   * the respective quizzes
+   * @param value the new sort category and order
+   */
+  changeSortAndOrder(value: ISort): void {
+    this.sort = value.sort;
+    this.order = value.order;
+
+    const params = new HttpParams().appendAll(
+      {
+        page: this.page.toString(),
+        sort: this.sort,
+        order: this.order,
+      },
+    );
+
+    this.location.replaceState(
+      location.pathname,
+      params.toString()
+    );
+
+    this.updateQuizzesEvent.emit({ page: this.page, sort: this.sort, order: this.order });
+  }
+
+  /**
+   * Updates the ``page`` property with the input, 
+   * the URL's string queries, and the catalogue with
+   * the respective quizzes
+   * @param page the new page
+   */
+  changePage(page: number): void {
+    this.page = page;
+    const params = new HttpParams().appendAll(
+      {
+        page: this.page.toString(),
+        sort: this.sort,
+        order: this.order,
+      },
+    );
+
+    this.location.replaceState(
+      location.pathname,
+      params.toString()
+    );
+
+    this.updateQuizzesEvent.emit({ page: this.page, sort: this.sort, order: this.order });
+  }
+
+}

--- a/src/app/shared/catalogue/catalogue.module.ts
+++ b/src/app/shared/catalogue/catalogue.module.ts
@@ -1,0 +1,17 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { CatalogueComponent } from './catalogue.component';
+
+
+
+@NgModule({
+  declarations: [],
+  imports: [
+    CommonModule,
+    CatalogueComponent
+  ],
+  exports: [
+    CatalogueComponent,
+  ],
+})
+export class CatalogueModule { }

--- a/src/app/shared/shared.module.ts
+++ b/src/app/shared/shared.module.ts
@@ -6,6 +6,7 @@ import { ShortenPipe } from './pipes/shorten/shorten.pipe';
 import { QuizListItemModule } from './quiz-list-item/quiz-list-item.module';
 import { CatalogueSelectMenuModule } from './catalogue-select-menu/catalogue-select-menu.module';
 import { CataloguePaginatorModule } from './catalogue-paginator/catalogue-paginator.module';
+import { CatalogueModule } from './catalogue/catalogue.module';
 
 @NgModule({
   imports: [
@@ -13,7 +14,8 @@ import { CataloguePaginatorModule } from './catalogue-paginator/catalogue-pagina
     QuestionModule,
     QuizFormModule,
     ShortenPipe,
-    QuizListItemModule
+    QuizListItemModule,
+    CatalogueModule,
   ],
   exports: [
     QuestionModule,
@@ -22,6 +24,7 @@ import { CataloguePaginatorModule } from './catalogue-paginator/catalogue-pagina
     ShortenPipe,
     CatalogueSelectMenuModule,
     CataloguePaginatorModule,
+    CatalogueModule,
   ],
 })
 export class SharedModule { }


### PR DESCRIPTION
Now you can use the ``<app-catalogue>`` component in any page which will render a list of quizzes and will want pagination and sorting. The all quizzes page has also been refactored to use it.