### PR TITLE
Add grade service

### DIFF
--- a/src/app/features/grade-services/README.md
+++ b/src/app/features/grade-services/README.md
@@ -1,0 +1,27 @@
+# GradeService
+An abstract service for grading questions.
+
+## Type parameters
+- ``TAnswer`` - the data type of a singular answer. For example, each answer of a multiple-choice question is represented by a string ID.
+- ``TAnswerSubmission`` - the data type of an answer submission. For example, multiple-choice questions are submitted as an array of string IDs, while a text question is submitted as a singular string value.
+
+## Methods
+```typescript
+abstract formatCorrectAnswers(correctAnswers: ISessionAnswer[] | null): TAnswer[] | null;
+```
+Should return an array of ``TAnswer`` values or ``null`` if the question has not been graded yet. Implementation is left to the class that inherits this service.
+
+```typescript
+abstract grade(answers: TAnswerSubmission, correctAnswers: ISessionAnswer[] | null): boolean | null;
+```
+Should return a boolean value that indicates whether the question has been answered correctly or ``null`` if the question has not been graded. Implementation is left to the class that inherits this service.
+
+```typescript
+abstract generateGradedAnswerClass(answer: TAnswer, correctAnswers: ISessionAnswer[] | null): "correct-answer" | "wrong-answer" | "not-graded";
+```
+Should return a class name that indicates whether a particular answer is correct, wrong, or yet to be graded. Implementation is left to the class that inherits this service.
+
+```typescript
+function generatePromptClass(isCorrect: boolean | null): "unanswered" | "correct" | "wrong"
+```
+Returns a class name that indicates whether the user's answers are correct, wrong, or have to be graded.

--- a/src/app/features/grade-services/grade.service.spec.ts
+++ b/src/app/features/grade-services/grade.service.spec.ts
@@ -1,0 +1,30 @@
+import { TestBed } from '@angular/core/testing';
+
+import { GradeService } from './grade.service';
+
+describe('GradeServiceService', () => {
+  let service: GradeService<string, string[]>;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(GradeService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  describe('generatePromptClass', () => {
+    it('Returns "unanswered" if isCorrect is null', () => {
+      expect(service.generatePromptClass(null)).toBe('unanswered');
+    });
+
+    it('Returns "wrong" if isCorrect is false', () => {
+      expect(service.generatePromptClass(false)).toBe('wrong');
+    });
+
+    it('Returns "correct" if isCorrect is true', () => {
+      expect(service.generatePromptClass(true)).toBe('correct');
+    });
+  });
+});

--- a/src/app/features/grade-services/grade.service.ts
+++ b/src/app/features/grade-services/grade.service.ts
@@ -1,0 +1,47 @@
+import { Injectable } from '@angular/core';
+import { ISessionAnswer } from '../../../types/responses/quiz.types';
+
+/**
+ * An abstract class that provides the required methods for any specific
+ * implementation of a grade service. ``TAnswer`` represents the type of the
+ * answer. ``TAnswerSubmission`` represents the type of the submitted answers
+ * (for example, multiple choice questions are submitted with an array of
+ * strings, while text questions are submitted with a singular string).
+ */
+@Injectable({
+  providedIn: 'root',
+})
+export abstract class GradeService<TAnswer, TAnswerSubmission> {
+  /**
+   * Returns an array of ``TAnswer`` values or ``null`` if the question has not been graded yet.
+   * @param correctAnswers the correct answers or ``null`` 
+   * if the question is not graded yet
+   */
+  abstract formatCorrectAnswers(correctAnswers: ISessionAnswer[] | null): TAnswer[] | null;
+
+  /**
+   * @param answers the user's answers
+   * @param correctAnswers the correct answers or ``null`` if the question has
+   * not been graded yet.
+   * @returns a boolean value that indicates whether the user has answered
+   * correctly or ``null`` if ``correctAnswers`` is ``null``.
+   */
+  abstract grade(answers: TAnswerSubmission, correctAnswers: ISessionAnswer[] | null): boolean | null;
+
+  generatePromptClass(isCorrect: boolean | null): "unanswered" | "correct" | "wrong" {
+    if (isCorrect === null) {
+      return 'unanswered';
+    }
+
+    return isCorrect ? 'correct' : 'wrong';
+  }
+
+  /**
+   * @param answer The answer of the control
+   * @param correctAnswers The correct answers or ``null`` if the question
+   * has not been graded yet.
+   * @returns A class name that can be used to apply styling to the answer
+   * based on whether it's correct, wrong, or yet to be graded.
+   */
+  abstract generateGradedAnswerClass(answer: TAnswer, correctAnswers: ISessionAnswer[] | null): "correct-answer" | "wrong-answer" | "not-graded";
+}

--- a/src/app/features/grade-services/multiple-choice-grader-service/README.md
+++ b/src/app/features/grade-services/multiple-choice-grader-service/README.md
@@ -1,0 +1,33 @@
+# MultipleChoiceGraderService
+
+## Methods
+```typescript
+function formatCorrectAnswers(correctAnswers: ISessionAnswer[] | null): string[] | null
+```
+Returns an array containing the answer ID as the only value or ``null`` if ``correctAnswers`` is ``null``.
+
+```typescript
+function grade(answers: string, correctAnswers: ISessionAnswer[] | null): boolean | null
+```
+Returns ``null`` if the question has not been graded or a boolean value that
+indicates whether the question has been answered correctly.
+
+The question is considered correct if the user has checked all correct answers
+and has not checked any wrong answers (order does not matter). This method uses
+a superset algorithm to compare the user's answer to the correct answers.
+This algorithm asymptotically takes O(n) time on average.
+
+**Note:** this method has an early exit for if the correct answers' amount
+is different from the user's answers'. If the correct answers looks like
+``[1, 2, 3]`` and the user answers look like ``[1, 2, 3, 3]``, this will still
+return ``false``.
+
+```typescript
+function generateGradedAnswerClass(answer: string, correctAnswers: ISessionAnswer[] | null): 'correct-answer' | 'wrong-answer' | 'not-graded'
+```
+Returns a string value that indicates whether the provided ``answer`` is correct or ungraded.
+
+```typescript
+function generatePromptClass(isCorrect: boolean | null): "unanswered" | "correct" | "wrong"
+```
+Returns a class name that indicates whether the user's answers are correct, wrong, or have to be graded. This method is inherited from ``GradeService``.

--- a/src/app/features/grade-services/multiple-choice-grader-service/README.md
+++ b/src/app/features/grade-services/multiple-choice-grader-service/README.md
@@ -7,7 +7,7 @@ function formatCorrectAnswers(correctAnswers: ISessionAnswer[] | null): string[]
 Returns an array containing the answer ID as the only value or ``null`` if ``correctAnswers`` is ``null``.
 
 ```typescript
-function grade(answers: string, correctAnswers: ISessionAnswer[] | null): boolean | null
+function grade(answers: string[], correctAnswers: ISessionAnswer[] | null): boolean | null
 ```
 Returns ``null`` if the question has not been graded or a boolean value that
 indicates whether the question has been answered correctly.

--- a/src/app/features/grade-services/multiple-choice-grader-service/multiple-choice-grader.service.spec.ts
+++ b/src/app/features/grade-services/multiple-choice-grader-service/multiple-choice-grader.service.spec.ts
@@ -1,0 +1,97 @@
+import { TestBed } from '@angular/core/testing';
+
+import { MultipleChoiceGraderService } from './multiple-choice-grader.service';
+import { ISessionAnswer } from '../../../../types/responses/quiz.types';
+
+function generateCorrectAnswers(n: number) {
+  const answers: ISessionAnswer[] = [];
+  for (let i = 1; i <= n; i++) {
+    answers.push(
+      {
+        id: i + '',
+        value: 'a',
+      }
+    );
+  }
+
+  return answers;
+}
+
+describe('MultipleChoiceGraderService', () => {
+  let service: MultipleChoiceGraderService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(MultipleChoiceGraderService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  describe('formatCorrectAnswers', () => {
+    it('Returns null if passed null', () => {
+      const result = service.formatCorrectAnswers(null);
+      expect(result).toBeNull();
+    });
+
+    it('Returns an array of the correct answer ID', () => {
+      const result = service.formatCorrectAnswers([
+        {
+          id: '1',
+          value: 'a',
+        },
+      ]);
+
+      expect(result).toEqual(['1']);
+    });
+  });
+
+  describe('grade', () => {
+    it('Returns null if correct answers are null', () => {
+      const result = service.grade(['1'], null);
+      expect(result).toBeNull();
+    });
+
+    it('Returns true if the answers match the correct answers (irrespective of order)', () => {
+      const result1 = service.grade(['1', '2', '3'], generateCorrectAnswers(3));
+      expect(result1).toBeTrue();
+
+      const result2 = service.grade(['1', '3', '2'], generateCorrectAnswers(3));
+    });
+
+    it('Returns false if the answer ID does not match the correct answer', () => {
+      const result1 = service.grade(['1'], generateCorrectAnswers(3));
+      expect(result1).toBeFalse();
+
+      const result2 = service.grade(['1', '2', '3', '4'], generateCorrectAnswers(3));
+      expect(result2).toBeFalse();
+
+      const result3 = service.grade(['1', '1', '2', '3'], generateCorrectAnswers(3));
+      expect(result3).toBeFalse();
+
+      const result4 = service.grade(['1', '3', '4'], generateCorrectAnswers(3));
+      expect(result4).toBeFalse();
+
+      const result5 = service.grade(['1', '1', '3'], generateCorrectAnswers(3));
+      expect(result5).toBeFalse();
+    });
+  });
+
+  describe('generateGradedAnswerClass', () => {
+    it('Returns ungraded if correct answers are null', () => {
+      const result = service.generateGradedAnswerClass('1', null);
+      expect(result).toBe('not-graded');
+    });
+
+    it('Returns "correct-answer" if the answer ID matches the correct answer', () => {
+      const result = service.generateGradedAnswerClass('1', [ { id: '1', value: 'a' }]);
+      expect(result).toBe('correct-answer');
+    });
+
+    it('Returns "wrong-answer" if the answer ID does not match the correct answer', () => {
+      const result = service.generateGradedAnswerClass('1', [ { id: '2', value: 'a' }]);
+      expect(result).toBe('wrong-answer');
+    });
+  });
+});

--- a/src/app/features/grade-services/multiple-choice-grader-service/multiple-choice-grader.service.ts
+++ b/src/app/features/grade-services/multiple-choice-grader-service/multiple-choice-grader.service.ts
@@ -1,0 +1,94 @@
+import { Injectable } from '@angular/core';
+import { GradeService } from '../grade.service';
+import { ISessionAnswer } from '../../../../types/responses/quiz.types';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class MultipleChoiceGraderService extends GradeService<string, string[]> {
+  /**
+   * @param correctAnswers the correct answers. ``null`` means that
+   * the question has not been graded yet
+   * @returns an array of the correct answers' IDs or ``null`` if ``correctAnswers``
+   * is ``null``.
+   */
+  override formatCorrectAnswers(correctAnswers: ISessionAnswer[] | null): string[] | null {
+    if (correctAnswers === null) {
+      return null;
+    }
+
+    return correctAnswers.map(ca => ca.id);
+  }
+
+  /**
+   * Returns ``null`` if the question has not been graded or a boolean value that
+   * indicates whether the question has been answered correctly.
+   * 
+   * The question is considered correct if the user has checked all correct answers
+   * and has not checked any wrong answers (order does not matter). This method uses
+   * a superset algorithm to compare the user's answer to the correct answers.
+   * This algorithm asymptotically takes O(n) time on average.
+   * 
+   * **Note:** this method has an early exit for if the correct answers' amount
+   * is different from the user's answers'. If the correct answers looks like
+   * ``[1, 2, 3]`` and the user answers look like ``[1, 2, 3, 3]``, this will still
+   * return ``false``.
+   * @param answers the user's answers
+   * @param correctAnswers the correct answers or ``null`` if the question has not
+   * been graded yet.
+   * @returns a boolean value that indicates whether the question is correct or wrong
+   * or ``null`` if the question has not been graded yet.
+   */
+  override grade(answers: string[], correctAnswers: ISessionAnswer[] | null): boolean | null {
+    const formattedCorrectAnswers = this.formatCorrectAnswers(correctAnswers);
+    if (formattedCorrectAnswers === null) {
+      return null;
+    }
+
+    if (answers.length !== formattedCorrectAnswers.length) {
+      return false;
+    }
+
+    const superSet = new Map<string, number>();
+    for (const answer of formattedCorrectAnswers) {
+      superSet.set(answer, 1);
+    }
+
+    for (const answer of answers) {
+      if (!answer) {
+        throw new Error('Empty string discovered');
+      }
+
+      if (!superSet.get(answer)) {
+        return false;
+      }
+
+      superSet.set(answer, 2);
+    }
+
+    for (const [_key, value] of superSet) {
+      if (value === 1) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  /**
+   * @param answer the ID of the specific answer
+   * @param correctAnswers the correct answers. ``null`` means that the question
+   * has not been graded yet.
+   * @returns A class name that indicates the answer's status. This can be used
+   * to style the answer control.
+   */
+  override generateGradedAnswerClass(answer: string, correctAnswers: ISessionAnswer[] | null): 'correct-answer' | 'wrong-answer' | 'not-graded' {
+    const formattedCorrectAnswers = this.formatCorrectAnswers(correctAnswers);
+    if (formattedCorrectAnswers === null) {
+      return 'not-graded';
+    }
+
+    return formattedCorrectAnswers.includes(answer) ? 'correct-answer' : 'wrong-answer';
+  }
+
+}

--- a/src/app/features/grade-services/single-choice-grader-service/README.md
+++ b/src/app/features/grade-services/single-choice-grader-service/README.md
@@ -1,0 +1,22 @@
+# SingleChoiceGraderService
+
+## Methods
+```typescript
+function formatCorrectAnswers(correctAnswers: ISessionAnswer[] | null): string[] | null
+```
+Returns an array containing the answer ID as the only value or ``null`` if ``correctAnswers`` is ``null``.
+
+```typescript
+function grade(answers: string, correctAnswers: ISessionAnswer[] | null): boolean | null
+```
+Returns ``null`` if ``correctAnswers`` is ``null`` or a boolean value indicating whether ``answers`` matches the ID in ``correctAnswers``.
+
+```typescript
+function generateGradedAnswerClass(answer: string, correctAnswers: ISessionAnswer[] | null): 'correct-answer' | 'wrong-answer' | 'not-graded'
+```
+Returns a string value that indicates whether the provided ``answer`` is correct or ungraded.
+
+```typescript
+function generatePromptClass(isCorrect: boolean | null): "unanswered" | "correct" | "wrong"
+```
+Returns a class name that indicates whether the user's answers are correct, wrong, or have to be graded. This method is inherited from ``GradeService``.

--- a/src/app/features/grade-services/single-choice-grader-service/README.md
+++ b/src/app/features/grade-services/single-choice-grader-service/README.md
@@ -4,7 +4,7 @@
 ```typescript
 function formatCorrectAnswers(correctAnswers: ISessionAnswer[] | null): string[] | null
 ```
-Returns an array containing the answer ID as the only value or ``null`` if ``correctAnswers`` is ``null``.
+Returns an array containing the correct answers' IDs or ``null`` if ``correctAnswers`` is ``null``.
 
 ```typescript
 function grade(answers: string, correctAnswers: ISessionAnswer[] | null): boolean | null

--- a/src/app/features/grade-services/single-choice-grader-service/single-choice-grader.service.spec.ts
+++ b/src/app/features/grade-services/single-choice-grader-service/single-choice-grader.service.spec.ts
@@ -1,0 +1,68 @@
+import { TestBed } from '@angular/core/testing';
+
+import { SingleChoiceGraderService } from './single-choice-grader.service';
+
+describe('SingleChoiceGraderService', () => {
+  let service: SingleChoiceGraderService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(SingleChoiceGraderService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  describe('formatCorrectAnswers', () => {
+    it('Returns null if passed null', () => {
+      const result = service.formatCorrectAnswers(null);
+      expect(result).toBeNull();
+    });
+
+    it('Returns an array of the correct answer ID', () => {
+      const result = service.formatCorrectAnswers([
+        {
+          id: '1',
+          value: 'a',
+        },
+      ]);
+
+      expect(result).toEqual(['1']);
+    });
+  });
+
+  describe('grade', () => {
+    it('Returns null if correct answers are null', () => {
+      const result = service.grade('1', null);
+      expect(result).toBeNull();
+    });
+
+    it('Returns true if the answer ID matches the correct answer', () => {
+      const result = service.grade('1', [ { id: '1', value: 'a' }]);
+      expect(result).toBeTrue();
+    });
+
+    it('Returns false if the answer ID does not match the correct answer', () => {
+      const result = service.grade('1', [ { id: '2', value: 'a' }]);
+      expect(result).toBeFalse();
+    });
+  });
+
+  describe('generateGradedAnswerClass', () => {
+    it('Returns ungraded if correct answers are null', () => {
+      const result = service.generateGradedAnswerClass('1', null);
+      expect(result).toBe('not-graded');
+    });
+
+    it('Returns "correct-answer" if the answer ID matches the correct answer', () => {
+      const result = service.generateGradedAnswerClass('1', [ { id: '1', value: 'a' }]);
+      expect(result).toBe('correct-answer');
+    });
+
+    it('Returns "wrong-answer" if the answer ID does not match the correct answer', () => {
+      const result = service.generateGradedAnswerClass('1', [ { id: '2', value: 'a' }]);
+      expect(result).toBe('wrong-answer');
+    });
+  });
+});

--- a/src/app/features/grade-services/single-choice-grader-service/single-choice-grader.service.ts
+++ b/src/app/features/grade-services/single-choice-grader-service/single-choice-grader.service.ts
@@ -1,0 +1,37 @@
+import { Injectable } from '@angular/core';
+import { GradeService } from '../grade.service';
+import { ISessionAnswer } from '../../../../types/responses/quiz.types';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class SingleChoiceGraderService extends GradeService<string, string> {
+  override formatCorrectAnswers(correctAnswers: ISessionAnswer[] | null): string[] | null {
+    if (correctAnswers === null) {
+      return null;
+    }
+
+    return correctAnswers.map(ca => ca.id);
+  }
+
+  override grade(answers: string, correctAnswers: ISessionAnswer[] | null): boolean | null {
+    const formattedCorrectAnswers = this.formatCorrectAnswers(correctAnswers);
+    if (formattedCorrectAnswers === null) {
+      return null;
+    }
+
+    const correctAnswer = formattedCorrectAnswers[0];
+    return answers === correctAnswer;
+  }
+
+  override generateGradedAnswerClass(answer: string, correctAnswers: ISessionAnswer[] | null): 'correct-answer' | 'wrong-answer' | 'not-graded' {
+    const isCorrect = this.grade(answer, correctAnswers);
+
+    if (isCorrect === null) {
+      return 'not-graded';
+    }
+
+    return isCorrect ? 'correct-answer' : 'wrong-answer';
+  }
+
+}

--- a/src/app/features/grade-services/text-grader-service/README.md
+++ b/src/app/features/grade-services/text-grader-service/README.md
@@ -1,0 +1,22 @@
+# TextGraderService
+
+## Methods
+```typescript
+function formatCorrectAnswers(correctAnswers: ISessionAnswer[] | null): string[] | null
+```
+Returns an array containing the correct answers' values or ``null`` if ``correctAnswers`` is ``null``.
+
+```typescript
+function grade(answers: string, correctAnswers: ISessionAnswer[] | null): boolean | null
+```
+Returns ``null`` if ``correctAnswers`` is ``null`` or a boolean value indicating whether ``answers``is contained within ``correctAnswers``. The search is case- and space-insensitive. The answers are also trimmed on both ends.
+
+```typescript
+function generateGradedAnswerClass(answer: string, correctAnswers: ISessionAnswer[] | null): 'correct-answer' | 'wrong-answer' | 'not-graded'
+```
+Returns a string value that indicates whether the provided ``answer`` is correct, wrong, or ungraded.
+
+```typescript
+function generatePromptClass(isCorrect: boolean | null): "unanswered" | "correct" | "wrong"
+```
+Returns a class name that indicates whether the user's answers are correct, wrong, or have to be graded. This method is inherited from ``GradeService``.

--- a/src/app/features/grade-services/text-grader-service/text-grader.service.spec.ts
+++ b/src/app/features/grade-services/text-grader-service/text-grader.service.spec.ts
@@ -1,0 +1,51 @@
+import { TestBed } from '@angular/core/testing';
+
+import { TextGraderService } from './text-grader.service';
+
+describe('TextGraderService', () => {
+  let service: TextGraderService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(TextGraderService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  describe('formatCorrectAnswers', () => {
+    it('Returns null if passed null', () => {
+      const result = service.formatCorrectAnswers(null);
+      expect(result).toBeNull();
+    });
+
+    it('Returns an array of the correct answer ID', () => {
+      const result = service.formatCorrectAnswers([
+        {
+          id: '1',
+          value: 'a',
+        },
+      ]);
+
+      expect(result).toEqual(['a']);
+    });
+  });
+
+  describe('grade', () => {
+    it('Returns null if correct answers are null', () => {
+      const result = service.grade('a', null);
+      expect(result).toBeNull();
+    });
+
+    it('Returns true if the answer ID matches the correct answer', () => {
+      const result = service.grade('   cAn Ad A    ', [ { id: '1', value: 'Canada' }]);
+      expect(result).toBeTrue();
+    });
+
+    it('Returns false if the answer ID does not match the correct answer', () => {
+      const result = service.grade('b', [ { id: '2', value: 'a' }]);
+      expect(result).toBeFalse();
+    });
+  });
+});

--- a/src/app/features/grade-services/text-grader-service/text-grader.service.ts
+++ b/src/app/features/grade-services/text-grader-service/text-grader.service.ts
@@ -1,0 +1,44 @@
+import { Injectable } from '@angular/core';
+import { GradeService } from '../grade.service';
+import { ISessionAnswer } from '../../../../types/responses/quiz.types';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class TextGraderService extends GradeService<string, string> {
+  override generateGradedAnswerClass(answer: string, correctAnswers: ISessionAnswer[] | null): 'correct-answer' | 'wrong-answer' | 'not-graded' {
+    const isCorrect = this.grade(answer, correctAnswers);
+    if (isCorrect === null) {
+      return 'not-graded';
+    }
+
+    return isCorrect ? 'correct-answer' : 'wrong-answer';
+  }
+  override formatCorrectAnswers(correctAnswers: ISessionAnswer[] | null): string[] | null {
+    if (correctAnswers === null) {
+      return null;
+    }
+
+    return correctAnswers.map(ca => ca.value);
+  }
+
+  override grade(answers: string, correctAnswers: ISessionAnswer[] | null): boolean | null {
+    const formattedCorrectAnswers = this.formatCorrectAnswers(correctAnswers);
+    if (formattedCorrectAnswers === null) {
+      return null;
+    }
+
+    const normalizedAnswers = formattedCorrectAnswers.map(this.normalizeAnswer);
+    return normalizedAnswers.includes(this.normalizeAnswer(answers));
+  }
+
+  /**
+   * Returns a normalized variant of ``answer``, which is trimmed (on both ends),
+   * has all letters uppercased, and has all spaces removed.
+   * @param answer 
+   * @returns a trimmed and uppercased ``answer`` with all spaces removed.
+   */
+  private normalizeAnswer(answer: string) {
+    return answer.trim().toUpperCase().replaceAll(' ', '');
+  }
+}

--- a/src/app/features/quiz-details/session/quiz-session/question-session/multiple-choice-question/README.md
+++ b/src/app/features/quiz-details/session/quiz-session/question-session/multiple-choice-question/README.md
@@ -43,23 +43,6 @@ Certain elements in this component have dynamic class names, which allows you to
 * Each checkbox text has a class name of ``not-graded``, ``wrong-answer``, or ``correct-answer``. The checkbox text has a class name of ``not-graded`` when the question has not been graded yet.
 
 ## Methods and getters
-```typescript
-get isCorrect(): boolean | null
-```
-Returns ``null`` if ``correctAnswers`` is ``null`` (which means that the question has not been graded yet) or a boolean value that indicates whether the user has answered correctly or not. The user has answered correctly if they have given all correct answers and have not given any wrong answer. The order of the answers does not matter.
-
-This getter uses a superset algorithm to compare the user's answer to the correct answers. This algorithm asymptotically takes O(n) time on average.
-
-**Note:** this getter has an early exit for if the correct answers' amount
-is different from the user's answers'. If the correct answers looks like
-``[1, 2, 3]`` and the user answers look like ``[1, 2, 3, 3]``, this will still
-return ``false``, even though all of the user's answers are technically correct.
-
-
-```typescript
-function answerClass(id: number): "not-graded" | "correct-answer" | "wrong-answer";
-```
-Returns a string that indicates whether the answer with the given ID is correct or wrong, which can be used as a class name within the template. If the question has not been graded (aka ``correctAnswers`` is ``null``), the method will return ``not-graded``.
 
 ```typescript
 function updateAnswers(event: MatCheckboxChange): void

--- a/src/app/features/quiz-details/session/quiz-session/question-session/multiple-choice-question/multiple-choice-question.component.spec.ts
+++ b/src/app/features/quiz-details/session/quiz-session/question-session/multiple-choice-question/multiple-choice-question.component.spec.ts
@@ -18,7 +18,7 @@ describe('MultipleChoiceQuestionComponent', () => {
   let element: HTMLElement;
   const fb = new FormBuilder();
 
-  describe('Unit tests', () => {
+  describe('Integration tests', () => {
     beforeEach(() => {
       TestBed.configureTestingModule({
         imports: [
@@ -35,85 +35,6 @@ describe('MultipleChoiceQuestionComponent', () => {
 
     it('should create', () => {
       expect(component).toBeTruthy();
-    });
-
-    describe('isCorrect getter', () => {
-      it('Returns null if correctAnswers is null', () => {
-        component.correctAnswers = null;
-        const result = component.isCorrect;
-        expect(result).toBeNull();
-      });
-
-      it('Returns false if the correct and current answers are of different lengths', () => {
-        setAnswers(1, 2, 3, 4);
-        
-        component.correctAnswers = [
-          { id: '1', value: 'a' }, { id: '2', value: 'b' },
-          { id: '3', value: 'c' },
-        ];
-
-        const result = component.isCorrect;
-        expect(result).toBeFalse();
-
-        setAnswers(3, 1);
-        const result2 = component.isCorrect;
-        expect(result2).toBeFalse();
-
-        setAnswers(1, 2, 3, 4);
-        const result3 = component.isCorrect;
-        expect(result3).toBeFalse();
-      });
-
-      it('Returns false if the correct and current answers do not match', () => {
-        setAnswers(2, 1, 4);
-        component.correctAnswers = [
-          { id: '1', value: 'a' }, { id: '2', value: 'b' },
-          { id: '3', value: 'c' },
-        ];
-
-        const result = component.isCorrect;
-        expect(result).toBeFalse();
-      });
-
-      it('Returns true if the correct and current answers match', () => {
-        setAnswers(2, 1, 3);
-        component.correctAnswers = [
-          { id: '1', value: 'a' }, { id: '2', value: 'b' },
-          { id: '3', value: 'c' },
-        ];
-
-        const result = component.isCorrect;
-        expect(result).toBeTrue();
-
-        setAnswers(3, 2, 1);
-        expect(component.isCorrect).toBeTrue();
-      });
-    });
-
-    describe('answerClass', () => {
-      it('Returns correct name for an ungraded question', () => {
-        component.correctAnswers = null;
-        const result = component.answerClass('');
-
-        expect(result).toBe('not-graded');
-      });
-
-      it('Returns correct name for a correct answer', () => {
-        component.correctAnswers = [{ value: 'correct', id: '1' }, { value: 'correct2', id: '2' }];
-
-        const result = component.answerClass('1');
-        expect(result).toBe('correct-answer');
-
-        const result2 = component.answerClass('2');
-        expect(result2).toBe('correct-answer');
-      });
-
-      it('Returns correct name for a wrong answer', () => {
-        component.correctAnswers = [{ value: 'correct', id: '1' }];
-
-        const result = component.answerClass('2');
-        expect(result).toBe('wrong-answer');
-      });
     });
 
     describe('updateAnswers', () => {

--- a/src/app/features/quiz-details/session/quiz-session/question-session/question-session.component.spec.ts
+++ b/src/app/features/quiz-details/session/quiz-session/question-session/question-session.component.spec.ts
@@ -1,9 +1,9 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { QuestionSessionComponent } from './question-session.component';
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { api } from '../../../../../constants/api.constants';
-import { ISessionAnswer } from '../../../../../../types/responses/quiz.types';
+import { IGradedAnswer, ISessionAnswer } from '../../../../../../types/responses/quiz.types';
 import { HttpResponse, HttpStatusCode } from '@angular/common/http';
 import { AnswerService } from '../../../../answer-service/answer.service';
 import { Observable } from 'rxjs';
@@ -236,7 +236,7 @@ describe('QuestionSessionComponent', () => {
         expect(button.disabled).toBeFalse();
       });
 
-      it('A successful request from clicking the button disables the button', () => {
+      it('A successful request from clicking the button disables the button', waitForAsync(async () => {
         component.instantMode = true;
         component.type = shortQuestionTypes[questionTypes.text];
         component.version = 1;
@@ -249,14 +249,21 @@ describe('QuestionSessionComponent', () => {
 
         const button = element.querySelector('.grade-btn') as HTMLButtonElement;
         button.click();
-        fixture.detectChanges();
+        fixture.whenStable().then(() => {
+          fixture.detectChanges();
+          expect(button.disabled).toBeTrue();
+        });
 
-        const responseBody: ISessionAnswer[] = [
+        const responseBody: IGradedAnswer = 
           {
             id: '1',
-            value: 'correct',
-          },
-        ];
+            answers: [
+              {
+                value: 'correct',
+                id: '1',
+              }
+            ]
+          };
 
         const request = testController.expectOne(api.endpoints.answers.correctAnswersInstantMode('1') + '?version=1');
 
@@ -264,10 +271,7 @@ describe('QuestionSessionComponent', () => {
           status: HttpStatusCode.Ok,
           statusText: 'Ok',
         });
-
-        fixture.detectChanges();
-        expect(button.disabled).toBeTrue();
-      });
+      }));
 
       it('An unsuccessful request from clicking the button does NOT disable the button', () => {
         component.instantMode = true;

--- a/src/app/features/quiz-details/session/quiz-session/question-session/question-session.component.ts
+++ b/src/app/features/quiz-details/session/quiz-session/question-session/question-session.component.ts
@@ -28,9 +28,9 @@ export class QuestionSessionComponent implements OnChanges, OnDestroy {
   protected types = shortQuestionTypes;
 
   constructor(
-      private readonly answerService: AnswerService,
-      private readonly fb: FormBuilder,
-    ) { }
+    private readonly answerService: AnswerService,
+    private readonly fb: FormBuilder,
+  ) { }
 
   @Input({ required: true }) version = 0;
   @Input({ required: true }) prompt: string = '';
@@ -51,8 +51,8 @@ export class QuestionSessionComponent implements OnChanges, OnDestroy {
   });
 
   ngOnChanges(changes: SimpleChanges) {
-    const change = changes['correctAnswers'];    
-    
+    const change = changes['correctAnswers'];
+
     if (!change.firstChange) {
       this.correctAnswers = change.currentValue;
     }
@@ -78,18 +78,18 @@ export class QuestionSessionComponent implements OnChanges, OnDestroy {
     event.preventDefault();
     if (this.instantMode && this.form.enabled) {
       this.correctAnswersSub = this.answerService
-      .getCorrectAnswersForQuestionById(this.questionId, this.version)
-      .subscribe({
-        next: res => {
-          const value = res.body!;
-          
-          this.correctAnswers = value.answers;
-          this.form.disable();          
-        },
-        error: (err: HttpErrorResponse) => {
-          console.warn(err);
-        }
-      });
+        .getCorrectAnswersForQuestionById(this.questionId, this.version)
+        .subscribe({
+          next: res => {
+            const value = res.body!;            
+            this.correctAnswers = value.answers;
+            
+            this.form.disable();
+          },
+          error: (err: HttpErrorResponse) => {
+            console.warn(err);
+          }
+        });
     }
   }
 

--- a/src/app/features/quiz-details/session/quiz-session/question-session/single-choice-question/single-choice-question/README.md
+++ b/src/app/features/quiz-details/session/quiz-session/question-session/single-choice-question/single-choice-question/README.md
@@ -36,21 +36,3 @@ Certain elements in this component have dynamic class names, which allows you to
 * Question prompt heading, which has a class name of ``unanswered``, ``correct``, or ``wrong`` depending on the question's status.
 
 * Each checkbox text has a class name of ``not-graded``, ``wrong-answer``, or ``correct-answer``. The checkbox text has a class name of ``not-graded`` when the question has not been graded yet.
-
-## Methods and getters
-```typescript
-get isCorrect(): boolean | null
-```
-Returns ``null`` if ``correctAnswers`` is ``null`` (which means that the question has not been graded yet) or a boolean value that indicates whether the user has answered correctly or not. The user has answered correctly if they have picked the correct answer (aka the radio button whose ID matches the correct answer's).
-
-
-```typescript
-function answerClass(id: number): "not-graded" | "correct-answer" | "wrong-answer";
-```
-Returns a string that indicates whether the answer with the given ID is correct or wrong, which can be used as a class name within the template. If the question has not been graded (aka ``correctAnswers`` is ``null``), the method will return ``not-graded``.
-
-```typescript
-get correctAnswer(): number | null
-```
-
-Returns the ID of the correct answer or ``null`` if ``correctAnswers`` is ``null (aka the question has not been graded)

--- a/src/app/features/quiz-details/session/quiz-session/question-session/single-choice-question/single-choice-question/single-choice-question.component.spec.ts
+++ b/src/app/features/quiz-details/session/quiz-session/question-session/single-choice-question/single-choice-question/single-choice-question.component.spec.ts
@@ -1,6 +1,8 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { SingleChoiceQuestionComponent } from './single-choice-question.component';
+import { GradeService } from '../../../../../../grade-services/grade.service';
+import { SingleChoiceGraderService } from '../../../../../../grade-services/single-choice-grader-service/single-choice-grader.service';
 
 describe('SingleChoiceQuestionComponent', () => {
   let component: SingleChoiceQuestionComponent;
@@ -10,7 +12,13 @@ describe('SingleChoiceQuestionComponent', () => {
   describe('Unit tests', () => {
     beforeEach(() => {
       TestBed.configureTestingModule({
-        imports: [SingleChoiceQuestionComponent]
+        imports: [SingleChoiceQuestionComponent],
+        providers: [
+          {
+            provide: GradeService,
+            useClass: SingleChoiceGraderService,
+          }
+        ]
       });
       fixture = TestBed.createComponent(SingleChoiceQuestionComponent);
       component = fixture.componentInstance;
@@ -19,55 +27,6 @@ describe('SingleChoiceQuestionComponent', () => {
 
     it('should create', () => {
       expect(component).toBeTruthy();
-    });
-
-    describe('isCorrect getter', () => {
-      it('Returns null if correctAnswer is null', () => {
-        component.correctAnswers = null;
-        const result = component.isCorrect;
-        expect(result).toBeNull();
-      });
-
-      it('Returns true if correctAnswer matches currentAnswer', () => {
-        component.correctAnswers = [ { id: '1', value: 'correct '}];
-        component.form.controls.currentAnswer.setValue('1');
-
-        const result = component.isCorrect;
-        expect(result).toBeTrue();
-      });
-
-      it('Returns false if currentAnswer does not match correctAnswer', () => {
-        component.correctAnswers = [ { id: '1', value: 'correct' }];
-        component.form.controls.currentAnswer.setValue('2');
-
-        const result = component.isCorrect;
-        expect(result).toBeFalse();
-      });
-    });
-
-    describe('answerClass', () => {
-      it('Returns correct name for an ungraded question', () => {
-        component.correctAnswers = null;
-        const result = component.answerClass('0');
-
-        expect(result).toBe('not-graded');
-      });
-
-      it('Returns correct name for a correct answer', () => {
-        component.correctAnswers = [ { value: 'correct', id: '1' }];
-        component.form.controls.currentAnswer.setValue('1');
-
-        const result = component.answerClass('1');
-        expect(result).toBe('correct-answer');
-      });
-
-      it('Returns correct name for a wrong answer', () => {
-        component.correctAnswers = [ { value: 'correct', id: '1' }];
-        component.form.controls.currentAnswer.setValue('1');
-
-        const result = component.answerClass('2');
-        expect(result).toBe('wrong-answer');
-      });
     });
   });
 

--- a/src/app/features/quiz-details/session/quiz-session/question-session/text-question/README.md
+++ b/src/app/features/quiz-details/session/quiz-session/question-session/text-question/README.md
@@ -34,9 +34,3 @@ Certain elements in this component have dynamic class names, which allows you to
 
 * Question prompt heading, which has a class name of ``unanswered``, ``correct``, or ``wrong`` depending on the question's status.
 
-## Getters
-```typescript
-get isCorrect(): boolean | null
-```
-Returns ``null`` if ``correctAnswers`` is ``null`` (which means that the question has not been graded yet) or a boolean value that indicates whether the user has answered correctly or not. The user has answered correctly if they have typed a correct answer. The grading is case insensitive (so if the answer to the question is Canada, then canada, CANADA, and cANadA would all be considered correct).
-

--- a/src/app/features/quiz-details/session/quiz-session/question-session/text-question/text-question.component.spec.ts
+++ b/src/app/features/quiz-details/session/quiz-session/question-session/text-question/text-question.component.spec.ts
@@ -22,51 +22,6 @@ describe('TextQuestionComponent', () => {
     it('should create', () => {
       expect(component).toBeTruthy();
     });
-
-    describe('isCorrect getter', () => {
-      it('Returns null if the correctAnswers property is null', () => {
-        component.correctAnswers = null;
-        const result = component.isCorrect;
-        expect(result).toBeNull();
-      });
-
-      it('Returns false if the correct answers property does not include the user\'s answer', () => {
-        component.correctAnswers = [
-          {
-            id: '1',
-            value: 'correct',
-          }
-        ];
-
-        component.form.controls.currentAnswer.setValue('wrong');
-        const result = component.isCorrect;
-        expect(result).toBeFalse();
-      });
-
-      it('Returns true if the correct answers property includes the user\'s answer (case insensitive)', () => {
-        component.correctAnswers = [
-          {
-            id: '1',
-            value: 'correct',
-          }
-        ];
-
-        component.form.controls.currentAnswer.setValue('cORRecT');
-        const result = component.isCorrect;
-        expect(result).toBeTrue();
-      });
-    });
-
-    describe('ngOnChanges', () => {
-      it('Sets the correctAnswers property to whatever changes have come', () => {
-        const changes = new SimpleChange(null, [{ id: '1', value: 'correct' }], true);
-        component.ngOnChanges({
-          correctAnswers: changes,
-        });
-
-        expect(component.correctAnswers).toEqual([{ id: '1', value: 'correct' }]);
-      });
-    });
   });
 
   describe('Component tests', () => {


### PR DESCRIPTION
This refactor introduces the following changes:
- all components delegate their grading logic to the new `GradeService` class.

- This class is an abstract one and is currently inherited by three classes, one for each type of question

- like the previous refactor, many tests were removed from the components, as the tested behavior is covered by the grade services' tests. 