### PR TITLE
Refactor catalogue

### DIFF
--- a/src/app/routing/app-routing.module.ts
+++ b/src/app/routing/app-routing.module.ts
@@ -67,7 +67,7 @@ const routes: Routes = [
 ];
 
 @NgModule({
-  imports: [RouterModule.forRoot(routes)],
+  imports: [RouterModule.forRoot(routes, { onSameUrlNavigation: 'reload' })],
   exports: [RouterModule]
 })
 export class AppRoutingModule { }

--- a/src/app/shared/catalogue-select-menu/README.md
+++ b/src/app/shared/catalogue-select-menu/README.md
@@ -2,10 +2,22 @@
 
 ## Usage
 ```html
-<app-catalogue-select-menu (select)="myFunc($event)"></app-catalogue-select-menu>
+<app-catalogue-select-menu (select)="myFunc($event)" (selectedValue)="title-desc"
+[options]="{ 'Title (Descending)': 'title-desc'}"></app-catalogue-select-menu>
 ```
 
-### @Output events
-* ``select`` - an event that is emitted when the user selects a new option from the menu. The ``$event`` is of type ``ISort`` and holds the sort options the user wants.
+### @Input properties
+```typescript
+class CatalogueSelectMenuComponent implements OnInit, OnChanges {
+  @Input({ required: true }) selectedValue = '';
+  @Input({ required: true }) options: Record<string, string> = {};
+}
+```
 
-Renders a ``<mat-select>`` that emits an event with the needed data when the user selects a new option. This is used to sort quizzes in a catalogue page. The parent component can use it to fetch the quizzes in the desired order.
+* ``options`` - key-value pairs of strings, representing all the options that will be rendered in the menu. The key is the text with which the option will be displayed and the value is the option's internal value (and the one that will be emitted when the user selects an option). The order of the options matches the order of the properties. (**Required**).
+* ``selectedValue`` - the initial value for the select menu (**Required**).
+
+### @Output events
+* ``select`` - an event that is emitted when the user selects a new option from the menu. The ``$event`` is of type ``string`` and holds the sort options the user wants.
+
+Renders a ``<mat-select>`` that emits an event with the needed data when the user selects a new option. This is used to sort items in a catalogue page. The parent component can use it to fetch data in the desired order.

--- a/src/app/shared/catalogue-select-menu/catalogue-select-menu.component.html
+++ b/src/app/shared/catalogue-select-menu/catalogue-select-menu.component.html
@@ -2,15 +2,10 @@
   <mat-form-field [formGroup]="form">
     <mat-label>Sort by</mat-label>
     <mat-select formControlName="value" (selectionChange)="select($event)">
-      <ng-container *ngFor="let category of categories">
-        <mat-option
-          *ngFor="let order of orderOptions"
-          [value]="category + '-' + order"
-          
-        >
-        {{ labels[category].sort }} ({{ labels[category][order] }})
-        </mat-option>
-      </ng-container>
+      <mat-option 
+        *ngFor="let option of options | keyvalue: originalOrder" [value]="option.value">
+        {{ option.key }}
+      </mat-option>
     </mat-select>
   </mat-form-field>
 </form>

--- a/src/app/shared/catalogue-select-menu/catalogue-select-menu.component.spec.ts
+++ b/src/app/shared/catalogue-select-menu/catalogue-select-menu.component.spec.ts
@@ -39,10 +39,7 @@ describe('CatalogueSelectMenuComponent', () => {
         change.value = 'title-asc';
         component.select(change);
 
-        expect(component.selectEvent.emit).toHaveBeenCalledOnceWith({
-          sort: 'title',
-          order: 'asc',
-        });
+        expect(component.selectEvent.emit).toHaveBeenCalledOnceWith('title-asc');
       });
 
       it('Sets the selectedValue property to the correct value', () => {
@@ -50,20 +47,6 @@ describe('CatalogueSelectMenuComponent', () => {
         component.select(change);
 
         expect(component.selectedValue).toBe('title-desc');
-      });
-    });
-
-    describe('constructQuery', () => {
-      it('constructs an object from the provided string', () => {
-        const result = component.constructQuery('title-asc');
-        expect(result).toEqual({
-          sort: 'title',
-          order: 'asc'
-        });
-      });
-
-      it('throws an error if it cannot parse the value', () => {
-        expect(() => component.constructQuery('nodash')).toThrow();
       });
     });
   });
@@ -85,6 +68,15 @@ describe('CatalogueSelectMenuComponent', () => {
   
     describe('Render', () => {
       it('Renders the correct amount of options', async () => {
+        component.options = {
+          'Title (Ascending)': 'title-asc',
+          'Title (Descending)': 'title-desc',
+          'Date of creation (Ascending)': 'createdOn-asc',
+          'Date of creation (Descending)': 'createdOn-desc',
+          'Last updated (Ascending)': 'updatedOn-asc',
+          'Last updated (Descending)': 'updatedOn-desc',
+        };
+        fixture.detectChanges();
         const select = await loader.getHarness(MatSelectHarness);
         await select.open();
         const options = await select.getOptions();
@@ -93,6 +85,14 @@ describe('CatalogueSelectMenuComponent', () => {
 
       it('Changes selected option based on the selectedValue property', async () => {
         component.selectedValue = 'title-desc';
+        component.options = {
+          'Title (Ascending)': 'title-asc',
+          'Title (Descending)': 'title-desc',
+          'Date of creation (Ascending)': 'createdOn-asc',
+          'Date of creation (Descending)': 'createdOn-desc',
+          'Last updated (Ascending)': 'updatedOn-asc',
+          'Last updated (Descending)': 'updatedOn-desc',
+        };
         component.ngOnInit();
         fixture.detectChanges();
 
@@ -100,17 +100,28 @@ describe('CatalogueSelectMenuComponent', () => {
         await select.open();
         fixture.detectChanges();
         
-        const value = await select.getValueText();
+        const value = await select.getValueText();        
         expect(value).toBe('Title (Descending)');
       });
     });
 
     describe('Changing an option', () => {
       it('Changes the selectedValue property when an option is clicked', async () => {
+        component.options = {
+          'Title (Ascending)': 'title-asc',
+          'Title (Descending)': 'title-desc',
+          'Date of creation (Ascending)': 'createdOn-asc',
+          'Date of creation (Descending)': 'createdOn-desc',
+          'Last updated (Ascending)': 'updatedOn-asc',
+          'Last updated (Descending)': 'updatedOn-desc',
+        };
+        fixture.detectChanges();
+
         const select = await loader.getHarness(MatSelectHarness);
         await select.open();
         fixture.detectChanges();
         const options = await select.getOptions();
+        
         const option = options[1];
         await option.click();
         fixture.detectChanges();

--- a/src/app/shared/catalogue-select-menu/catalogue-select-menu.component.ts
+++ b/src/app/shared/catalogue-select-menu/catalogue-select-menu.component.ts
@@ -1,16 +1,8 @@
 import { Component, EventEmitter, Input, OnChanges, OnInit, Output, SimpleChanges } from '@angular/core';
-import { CommonModule } from '@angular/common';
+import { CommonModule, KeyValue } from '@angular/common';
 import { ISort } from '../../../types/components/catalogue-select-menu.types';
 import { MatSelectChange, MatSelectModule } from '@angular/material/select';
-import { order, sort } from '../../../types/others/lists.types';
-import { sorting } from '../../constants/sorting.constants';
 import { FormBuilder, ReactiveFormsModule } from '@angular/forms';
-
-interface ILabel {
-  sort: string;
-  asc: 'Ascending';
-  desc: 'Descending';
-}
 
 @Component({
   selector: 'app-catalogue-select-menu',
@@ -24,16 +16,20 @@ interface ILabel {
   styleUrls: ['./catalogue-select-menu.component.scss']
 })
 export class CatalogueSelectMenuComponent implements OnInit, OnChanges {
-  constructor(private readonly fb: FormBuilder) {
-
-  }
+  constructor(private readonly fb: FormBuilder) {}
 
   ngOnInit(): void {
     this.form.controls.value.setValue(this.selectedValue);    
   }
 
-  @Output() selectEvent = new EventEmitter<ISort>();
-  @Input() selectedValue = 'title-asc';
+  @Output() selectEvent = new EventEmitter<string>();
+  @Input({ required: true }) selectedValue = '';
+
+  @Input({ required: true }) options: Record<string, string> = {};
+
+  protected originalOrder(a: KeyValue<string, string>, b: KeyValue<string, string>) { 
+    return 0;
+  }
 
   ngOnChanges(changes: SimpleChanges): void {
     const value = changes['selectedValue'];
@@ -44,47 +40,16 @@ export class CatalogueSelectMenuComponent implements OnInit, OnChanges {
     }
   }
 
-  protected readonly categories = sorting.categories;
-  protected readonly orderOptions = sorting.order;
-  protected readonly labels: Record<sort, ILabel> = {
-    title: {
-      sort: 'Title',
-      asc: 'Ascending',
-      desc: 'Descending'
-    },
-    createdOn: {
-      sort: 'Date of creation',
-      asc: 'Ascending',
-      desc: 'Descending',
-    },
-    updatedOn: {
-      sort: 'Last updated',
-      asc: 'Ascending',
-      desc: 'Descending'
-    }
-  }
-
   select(change: MatSelectChange) {
     const value = change.value as string;
-    const query = this.constructQuery(value);
     this.selectedValue = value;
     this.form.controls.value.setValue(this.selectedValue);
-    this.selectEvent.emit(query);
+    this.selectEvent.emit(value);
   }
 
   protected form = this.fb.group({
-    value: 'title-asc'
+    value: ''
   });
 
-  constructQuery(value: string): ISort {
-    if (!value.includes('-')) {
-      throw new Error('This option cannot be parsed');
-    }
-
-    const [sort, order] = value.split('-') as [sort, order];
-    return {
-      sort,
-      order,
-    };
-  }
+  
 }

--- a/src/app/shared/catalogue/README.md
+++ b/src/app/shared/catalogue/README.md
@@ -6,7 +6,7 @@
 ```
 
 ### @Input() properties
-* ``catalogue`` - an object of type ``IQuizList``. The component will use the data inside it to render the quizzes and the correct page. (**Required**)
+* ``catalogue`` - an object of type ``IQuizList``. The component will use the data inside it to render the quizzes and the correct page. (**Required**).
 
 ### @Output() properties
 * ``updateQuizzesEvent`` - this event is emitted every time the user changes the page or selects a new sorting category / order. The event passes an object containing the requested page, sort category, and order.
@@ -15,16 +15,16 @@ Renders an ``app-catalogue-select-menu``, a list of ``app-quiz-list-item`` eleme
 
 ## Methods
 ```typescript
-function getQueryString(query: string): string | null
+function getQueryParameters(): Observable<Params>;
 ```
-Returns the value of the given ``query`` from the URL or ``null`` if the query is missing.
+Returns the query parameters from the activated route.
 
 ```typescript
 function changeSortAndOrder(value: string): void
 ```
-``value`` in this case is passed in the format ``{category}-{order}``. This method will take the respective values and update the ``sort`` and ``order`` properties accordingly. In addition, this method will emit ``updateQuizzesEvent``, passing the current page and the new values as arguments. If there is a search query in the URL, it will be preserved.
+``value`` in this case is passed in the format ``{category}-{order}``. This method will take the respective values and update the ``sort`` and ``order`` properties accordingly. This method will navigate to the same URL, updating any changed query parameters (which on its own emits ``updateQuizzesEvent``).
 
 ```typescript
 function changePage(page: number): void
 ```
-Updates the ``page`` property to the passed argument and updates the URL's query strings to reflect that. In addition, this method will emit, ``updateQuizzesEvent`` passing the new page and the current sorting options as arguments. If there is a search query in the URL, it will be preserved.
+Updates the ``page`` property to the passed argument and updates the URL's query strings to reflect that. This method will navigate to the same URL, updating any changed query parameters (which on its own emits ``updateQuizzesEvent``).

--- a/src/app/shared/catalogue/README.md
+++ b/src/app/shared/catalogue/README.md
@@ -20,9 +20,9 @@ function getQueryString(query: string): string | null
 Returns the value of the given ``query`` from the URL or ``null`` if the query is missing.
 
 ```typescript
-function changeSortAndOrder(value: ISort): void
+function changeSortAndOrder(value: string): void
 ```
-Updates the ``sort`` and ``order`` properties to the passed ``value``'s respective properties and updates the URL's query strings to reflect that. In addition, this method will emit, ``updateQuizzesEvent`` passing the current page and the new values as arguments. If there is a search query in the URL, it will be preserved.
+``value`` in this case is passed in the format ``{category}-{order}``. This method will take the respective values and update the ``sort`` and ``order`` properties accordingly. In addition, this method will emit ``updateQuizzesEvent``, passing the current page and the new values as arguments. If there is a search query in the URL, it will be preserved.
 
 ```typescript
 function changePage(page: number): void

--- a/src/app/shared/catalogue/catalogue.component.html
+++ b/src/app/shared/catalogue/catalogue.component.html
@@ -1,5 +1,5 @@
 <app-catalogue-select-menu [selectedValue]="sortOrder"
-  (selectEvent)="changeSortAndOrder($event)"></app-catalogue-select-menu>
+  (selectEvent)="changeSortAndOrder($event)" [options]="options"></app-catalogue-select-menu>
 
 <div class="catalogue" *ngIf="catalogue.quizzes.length; else empty">
   <ng-container>

--- a/src/app/shared/catalogue/catalogue.component.spec.ts
+++ b/src/app/shared/catalogue/catalogue.component.spec.ts
@@ -143,7 +143,7 @@ describe('CatalogueComponent', () => {
       it('Changes the sort and order properties when called', () => {
         spyOn(location, 'replaceState').and.stub();
         spyOn(component.updateQuizzesEvent, 'emit');
-        component.changeSortAndOrder({ sort: 'createdOn', order: 'desc' });
+        component.changeSortAndOrder('createdOn-desc');
 
         expect(component.sort).toBe('createdOn');
         expect(component.order).toBe('desc');

--- a/src/app/shared/catalogue/catalogue.component.spec.ts
+++ b/src/app/shared/catalogue/catalogue.component.spec.ts
@@ -8,7 +8,7 @@ import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { MatPaginatorHarness } from '@angular/material/paginator/testing';
 import { HarnessLoader } from '@angular/cdk/testing';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
-import { RouterModule } from '@angular/router';
+import { ActivatedRoute, Router, RouterModule } from '@angular/router';
 import { QuizService } from '../../features/quiz-service/quiz.service';
 import { Observable, of } from 'rxjs';
 import { IQuizList, IQuizListItem } from '../../../types/others/lists.types';
@@ -44,10 +44,10 @@ describe('CatalogueComponent', () => {
   let component: CatalogueComponent;
   let fixture: ComponentFixture<CatalogueComponent>;
 
-  let location: Location;
   let loader: HarnessLoader;
 
   let element: HTMLElement;
+  let router: Router;
 
   beforeEach(() => {
     TestBed.configureTestingModule({
@@ -74,7 +74,7 @@ describe('CatalogueComponent', () => {
     });
 
     fixture = TestBed.createComponent(CatalogueComponent);
-    location = TestBed.inject(Location);
+    router = TestBed.inject(Router);
 
     loader = TestbedHarnessEnvironment.loader(fixture);
 
@@ -91,13 +91,13 @@ describe('CatalogueComponent', () => {
   describe('Unit tests', () => {
     describe('ngOnInit', () => {
       it('Sets all relevant properties based on query parameters', () => {
-        spyOn(component, 'getQueryString')
-          .withArgs('page')
-          .and.returnValue('121')
-          .withArgs('sort')
-          .and.returnValue('createdOn')
-          .withArgs('order')
-          .and.returnValue('desc');
+        spyOn(component, 'getQueryParams').and.returnValue(
+          of({
+            page: '121',
+            sort: 'createdOn',
+            order: 'desc',
+          })
+        );
 
         component.ngOnInit();
 
@@ -107,13 +107,13 @@ describe('CatalogueComponent', () => {
       });
 
       it('Sets all relevant properties from query parameters to default values if the query params are missing', () => {
-        spyOn(component, 'getQueryString')
-          .withArgs('page')
-          .and.returnValue(null)
-          .withArgs('sort')
-          .and.returnValue(null)
-          .withArgs('order')
-          .and.returnValue(null);
+        spyOn(component, 'getQueryParams').and.returnValue(
+          of({
+            page: undefined,
+            sort: undefined,
+            order: undefined,
+          })
+        );
 
         component.ngOnInit();
 
@@ -125,33 +125,24 @@ describe('CatalogueComponent', () => {
 
     describe('changePage', () => {
       it('Sets the page property when called', () => {
-        spyOn(location, 'replaceState').and.stub();
-        spyOn(component.updateQuizzesEvent, 'emit');
+        spyOn(router, 'navigate').and.stub();
 
         component.changePage(2);
         
-        expect(component.updateQuizzesEvent.emit).toHaveBeenCalledWith(
-          { page: 2, sort: 'title', order: 'asc' }
-        );
-
         expect(component.page).toBe(2);
-        expect(location.replaceState).toHaveBeenCalled();
+        expect(router.navigate).toHaveBeenCalled();
       });
     });
 
     describe('changeSortAndOrder', () => {
       it('Changes the sort and order properties when called', () => {
-        spyOn(location, 'replaceState').and.stub();
-        spyOn(component.updateQuizzesEvent, 'emit');
+        spyOn(router, 'navigate').and.stub();
         component.changeSortAndOrder('createdOn-desc');
 
         expect(component.sort).toBe('createdOn');
         expect(component.order).toBe('desc');
 
-        expect(location.replaceState).toHaveBeenCalled();
-        expect(component.updateQuizzesEvent.emit).toHaveBeenCalledWith(
-          { page: 1, sort: 'createdOn', order: 'desc' }
-        );
+        expect(router.navigate).toHaveBeenCalled();
       });
     });
   });
@@ -159,16 +150,15 @@ describe('CatalogueComponent', () => {
   describe('Component tests', () => {
     describe('component initilization', () => {
       it('Sets paginator to correct page based on query string', waitForAsync(async () => {
+        router.navigate(['/test'], {
+          queryParams: {
+            page: '3'
+          }
+        });
+        fixture.detectChanges();
+
         const paginators = await loader.getAllHarnesses(MatPaginatorHarness);
         const paginator = paginators[0];
-
-        spyOn(component, 'getQueryString')
-          .withArgs('page')
-          .and.returnValue('3')
-          .withArgs('sort')
-          .and.returnValue(null)
-          .withArgs('order')
-          .and.returnValue(null);
 
         component.ngOnInit();
         fixture.detectChanges();
@@ -185,13 +175,12 @@ describe('CatalogueComponent', () => {
         const selectMenus = await loader.getAllHarnesses(MatSelectHarness);
         const menu = selectMenus[0];
 
-        spyOn(component, 'getQueryString')
-          .withArgs('page')
-          .and.returnValue('3')
-          .withArgs('sort')
-          .and.returnValue('createdOn')
-          .withArgs('order')
-          .and.returnValue('desc');
+        spyOn(component, 'getQueryParams')
+          .and.returnValue(of({
+            page: '3',
+            sort: 'createdOn',
+            order: 'desc'
+          }));
 
         component.ngOnInit();
         fixture.detectChanges();
@@ -254,65 +243,6 @@ describe('CatalogueComponent', () => {
         const message2 = element.querySelector('.no-quizzes');
         expect(message2).toBeNull();
       });
-    });
-
-    describe('interaction', () => {
-      it('Changes location path when a new page is selected', waitForAsync(async () => {
-        component.catalogue = generateQuizzes(7);
-        const paginators = await loader.getAllHarnesses(MatPaginatorHarness);
-        const paginator = paginators[0];
-
-        component.ngOnInit();
-        fixture.detectChanges();
-
-        await paginator.goToNextPage();
-        fixture.detectChanges();
-
-        await fixture.whenStable();
-        
-        const path = location.path();
-        expect(path.includes('page=2')).toBeTrue();
-      }));
-
-      it('Changes location path when a new option is chosen', waitForAsync(async () => {
-        component.catalogue = generateQuizzes(7);
-        const menu = await loader.getHarness(MatSelectHarness);
-
-        component.ngOnInit();
-        fixture.detectChanges();
-
-        await menu.open();
-        fixture.detectChanges();
-
-        const options = await menu.getOptions();
-        await options[1].click();
-        fixture.detectChanges();
-
-        const path = location.path();
-        
-        expect(path.includes('sort=title')).toBeTrue();
-        expect(path.includes('order=desc')).toBeTrue();
-
-      }));
-
-      it('Retains the query param string when an update happens', waitForAsync(async () => {
-        component.catalogue = generateQuizzes(7);
-        const menu = await loader.getHarness(MatSelectHarness);
-
-        component.ngOnInit();
-        fixture.detectChanges();
-
-        spyOn(component, 'getQueryString').and.returnValue('mytitle');
-        await menu.open();
-        fixture.detectChanges();
-
-        const options = await menu.getOptions();
-        await options[1].click();
-        fixture.detectChanges();
-
-        const path = location.path();
-        expect(path.includes('query=mytitle')).toBe(true);
-      }))
     });
   });
 });

--- a/src/app/shared/catalogue/catalogue.component.ts
+++ b/src/app/shared/catalogue/catalogue.component.ts
@@ -1,8 +1,7 @@
-import { Component, EventEmitter, Input, OnDestroy, OnInit, Output } from '@angular/core';
+import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
 import { CommonModule, Location } from '@angular/common';
 import { IQuizList, order, sort } from '../../../types/others/lists.types';
 import { HttpParams } from '@angular/common/http';
-import { ISort } from '../../../types/components/catalogue-select-menu.types';
 import { CataloguePaginatorModule } from '../catalogue-paginator/catalogue-paginator.module';
 import { CatalogueSelectMenuComponent } from '../catalogue-select-menu/catalogue-select-menu.component';
 import { QuizListItemComponent } from '../quiz-list-item/quiz-list-item.component';
@@ -57,6 +56,15 @@ export class CatalogueComponent implements OnInit {
   sort: sort = 'title';
   order: order = 'asc';
 
+  protected options = {
+    'Title (Ascending)': 'title-asc',
+    'Title (Descending)': 'title-desc',
+    'Date of creation (Ascending)': 'createdOn-asc',
+    'Date of creation (Descending)': 'createdOn-desc',
+    'Last updated (Ascending)': 'updatedOn-asc',
+    'Last updated (Descending)': 'updatedOn-desc',
+  };
+
   protected get sortOrder() { return `${this.sort}-${this.order}` }
 
   /**
@@ -65,9 +73,11 @@ export class CatalogueComponent implements OnInit {
    * the respective quizzes
    * @param value the new sort category and order
    */
-  changeSortAndOrder(value: ISort): void {
-    this.sort = value.sort;
-    this.order = value.order;
+  changeSortAndOrder(value: string): void {
+    const query = value.split('-') as [sort, order];
+
+    this.sort = query[0];
+    this.order = query[1];
 
     this.updateURL();
 


### PR DESCRIPTION
This refactor introduces the following changes:
- the catalogue select menu can now be created with any kinds of options; simply pass it an object of key-value strings via its ``options`` input. This makes the component usable in other catalogue-like pages.

- The catalogue component now interacts better with the user's history; when the sorting or page is changed, a new entry is pushed into the history state. In addition, the component emits the updated values on query params changes, making the component functional when the user presses the back button.

- A few tests were removed because they, for the most parts, were testing the framework. 