### PR TITLE
Adapt the client to the API changes

### DIFF
--- a/src/app/common/api.ts
+++ b/src/app/common/api.ts
@@ -29,6 +29,7 @@ export const api = {
      */
     quiz: {
       create: quiz,
+      browse: quiz,
       /**
        * Endpoint for retrieving a specific quiz by its id.
        * @param id

--- a/src/app/common/api.ts
+++ b/src/app/common/api.ts
@@ -18,7 +18,7 @@ export const api = {
       register: `${auth}/register`,
       login: `${auth}/login`,
       logout: `${auth}/logout`,
-      usernameExists: (username: string) => `${auth}/username/${username}`,
+      usernameExists: `${auth}/username`,
       /** Endpoint to check if the user has a valid session upon app load */
       session: `${auth}/session`,
       profile: (id: string) => `${auth}/${id}`,
@@ -38,21 +38,18 @@ export const api = {
       id: (id: string | number) => `${quiz}/${id}`,
       edit: (id: string | number) => `${quiz}/${id}`,
       delete: (id: string | number) => `${quiz}/${id}`,
-      all: `${quiz}/all`,
-      search: `${quiz}/search`,
       user: (id: string) => `${quiz}/user/${id}`,
       quizForEdit: (id: number) => `${quiz}/${id}/edit`,
     },
     answers: {
-      correctAnswersInstantMode: (questionId: string) => `${answer}/${questionId}/question`,
-      correctAnswersFull: (quizId: number) => `${answer}/${quizId}/quiz`,
+      correctAnswersInstantMode: (questionId: string) => `${answer}/question/${questionId}`,
+      correctAnswersFull: (quizId: number) => `${answer}/quiz/${quizId}`,
     },
     logs: {
       getLogs: logs,
     },
 
     roles: {
-      getUsersOfRole: (role: string) => `${roles}/users/${role}`,
       promote: `${roles}/add`,
       demote: `${roles}/remove`,
       /**

--- a/src/app/common/api.ts
+++ b/src/app/common/api.ts
@@ -6,6 +6,7 @@ const quiz = `${root}/quiz`;
 const answer = `${root}/grade`;
 const logs = `${root}/logs`;
 const roles = `${root}/roles`;
+const profiles = `${root}/profile`;
 
 export const api = {
   root,
@@ -57,6 +58,10 @@ export const api = {
        * Use query string ``username`` to filter users.
        */
       getUsersOfUsername: () => `${roles}/users`,
+    },
+    profiles: {
+      getByUsername: (username: string) => `${profiles}/username/${username}`,
+      search: profiles,
     },
   },
 };

--- a/src/app/common/api.ts
+++ b/src/app/common/api.ts
@@ -53,8 +53,8 @@ export const api = {
 
     roles: {
       getUsersOfRole: (role: string) => `${roles}/users/${role}`,
-      promote: (userId: string, role: string) => `${roles}/promote/${userId}/${role}`,
-      demote: (userId: string, role: string) => `${roles}/demote/${userId}/${role}`,
+      promote: `${roles}/add`,
+      demote: `${roles}/remove`,
       /**
        * Use query string ``username`` to filter users.
        */

--- a/src/app/common/roles.ts
+++ b/src/app/common/roles.ts
@@ -7,3 +7,5 @@ export const roles: Record<roleKey, role> = {
   admin: 'Administrator',
 };
 
+export const rolesThatCanBeGivenOrRemoved: role[] = [roles.moderator];
+

--- a/src/app/common/search.ts
+++ b/src/app/common/search.ts
@@ -1,0 +1,18 @@
+import { sorting } from './sort';
+
+const DEFAULT_PAGE_SIZE_QUIZ = 5;
+const DEFAULT_PAGE_SIZE_LOGS = 20;
+const DEFAULT_PAGE_SIZE_USERS = 20;
+const DEFAULT_PAGE_SIZE_OPTIONS = [5, 10, 15, 20];
+
+const DEFAULT_ORDER = sorting.order[0];
+const DEFAULT_QUIZ_SORT_CATEGORY = sorting.categories[0];
+
+export const defaultSearchValues = {
+  DEFAULT_ORDER,
+  DEFAULT_PAGE_SIZE_LOGS,
+  DEFAULT_PAGE_SIZE_QUIZ,
+  DEFAULT_PAGE_SIZE_USERS,
+  DEFAULT_QUIZ_SORT_CATEGORY,
+  DEFAULT_PAGE_SIZE_OPTIONS,
+};

--- a/src/app/common/sort.ts
+++ b/src/app/common/sort.ts
@@ -39,3 +39,15 @@ export const sortAndOrderLabels: SortLabel[] = sorting.categories.map(
     ),
   ),
 ).reduce((acc, current) => acc.concat(current), []);
+
+export const activityLogsOrderLabels: Record<order, string> = sorting.order.reduce(
+  (state, order) => (
+    {...state, [order]: `Date ${order.toLowerCase()}`}
+  ), {} as Record<order, string>,
+);
+
+export const profileSearchOrderLabels: Record<order, string> = sorting.order.reduce(
+  (state, order) => (
+    {...state, [order]: `Username ${order.toLowerCase()}`}
+  ), {} as Record<order, string>,
+);

--- a/src/app/common/sort.ts
+++ b/src/app/common/sort.ts
@@ -1,14 +1,14 @@
-export type quizSort = 'title' | 'createdOn' | 'updatedOn';
-export type order = 'asc' | 'desc';
+export type quizSort = 'Title' | 'CreatedOn' | 'UpdatedOn';
+export type order = 'Ascending' | 'Descending';
 
 export interface SortAndOrder {
-  sort: quizSort;
+  sortBy: quizSort;
   order: order;
 }
 
 export const sorting = {
-  categories: ['title', 'createdOn', 'updatedOn'] as quizSort[],
-  order: ['asc', 'desc'] as order[],
+  categories: ['Title', 'CreatedOn', 'UpdatedOn'] as quizSort[],
+  order: ['Ascending', 'Descending'] as order[],
 };
 
 export interface SortLabel {
@@ -18,14 +18,14 @@ export interface SortLabel {
 }
 
 const sortingLabels: Record<quizSort, string> = {
-  title: 'Title',
-  createdOn: 'Date (created on)',
-  updatedOn: 'Date (last updated)',
+  Title: 'Title',
+  CreatedOn: 'Date (created on)',
+  UpdatedOn: 'Date (last updated)',
 };
 
 const orderLabels: Record<order, string> = {
-  asc: 'Ascending',
-  desc: 'Descending',
+  Ascending: 'Ascending',
+  Descending: 'Descending',
 };
 
 export const sortAndOrderLabels: SortLabel[] = sorting.categories.map(

--- a/src/app/components/admin/tab-sections/activity-logs-section/activity-logs-section.component.html
+++ b/src/app/components/admin/tab-sections/activity-logs-section/activity-logs-section.component.html
@@ -6,8 +6,8 @@
   <mat-form-field subscriptSizing="dynamic">
     <mat-label>Order by</mat-label>
     <mat-select formControlName="order">
-      <mat-option value="asc">Date (ascending)</mat-option>
-      <mat-option value="desc">Date (descending)</mat-option>
+      <mat-option value="Ascending">Date (ascending)</mat-option>
+      <mat-option value="Descending">Date (descending)</mat-option>
     </mat-select>
   </mat-form-field>
 </form>
@@ -33,5 +33,5 @@
   <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
   <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
 </mat-table>
-<mat-paginator [pageIndex]="(form.value.page || 1) - 1" showFirstLastButtons (page)="changePage($event.pageIndex + 1)" [pageSize]="20"
+<mat-paginator [pageSize]="20" [pageSizeOptions]="[5, 10, 15, 20]" [pageIndex]="(form.value.page || 1) - 1" showFirstLastButtons (page)="changePage($event)" [pageSize]="20"
   [length]="_logs.total"></mat-paginator>

--- a/src/app/components/admin/tab-sections/activity-logs-section/activity-logs-section.component.html
+++ b/src/app/components/admin/tab-sections/activity-logs-section/activity-logs-section.component.html
@@ -1,42 +1,44 @@
-@let _logs = logs();
+@let logs = (logs$ | async);
 
-<h2>Manage users</h2>
+@if (logs) {
+  <h2>Manage users</h2>
 
-<form [formGroup]="form" class="form">
-  <mat-form-field subscriptSizing="dynamic">
-    <mat-label>Order by</mat-label>
-    <mat-select [formControl]="form.controls.order">
-      <mat-option [value]="orders[0]">Date (ascending)</mat-option>
-      <mat-option [value]="orders[1]">Date (descending)</mat-option>
-    </mat-select>
-  </mat-form-field>
-</form>
+  <form [formGroup]="form" class="form">
+    <mat-form-field subscriptSizing="dynamic">
+      <mat-label>Order by</mat-label>
+      <mat-select [formControl]="form.controls.order">
+        <mat-option [value]="orders[0]">Date (ascending)</mat-option>
+        <mat-option [value]="orders[1]">Date (descending)</mat-option>
+      </mat-select>
+    </mat-form-field>
+  </form>
 
-<mat-table [dataSource]="_logs.logs">
-  <ng-container matColumnDef="index">
-    <th mat-header-cell *matHeaderCellDef>#</th>
-    <td mat-cell *matCellDef="let log"> {{ log.index }} </td>
-  </ng-container>
+  <mat-table [dataSource]="logs.logs">
+    <ng-container matColumnDef="index">
+      <th mat-header-cell *matHeaderCellDef>#</th>
+      <td mat-cell *matCellDef="let log"> {{ log.index }} </td>
+    </ng-container>
 
-  <ng-container matColumnDef="message">
-    <th mat-header-cell *matHeaderCellDef>Message</th>
-    <td mat-cell *matCellDef="let log"> {{ log.message }} </td>
-  </ng-container>
+    <ng-container matColumnDef="message">
+      <th mat-header-cell *matHeaderCellDef>Message</th>
+      <td mat-cell *matCellDef="let log"> {{ log.message }} </td>
+    </ng-container>
 
-  <ng-container matColumnDef="date">
-    <th mat-header-cell *matHeaderCellDef>Date</th>
-    <td mat-cell *matCellDef="let log">
-      {{ log.date | date: 'short' }}
-    </td>
-  </ng-container>
+    <ng-container matColumnDef="date">
+      <th mat-header-cell *matHeaderCellDef>Date</th>
+      <td mat-cell *matCellDef="let log">
+        {{ log.date | date: 'short' }}
+      </td>
+    </ng-container>
 
-  <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
-  <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
-</mat-table>
-<mat-paginator
-  [pageSize]="defaultSearchParameters.DEFAULT_PAGE_SIZE_LOGS"
-  [pageSizeOptions]="defaultSearchParameters.DEFAULT_PAGE_SIZE_OPTIONS"
-  [pageIndex]="(form.value.page || 1) - 1"
-  showFirstLastButtons (page)="changePage($event)"
-  [length]="_logs.total">
-</mat-paginator>
+    <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+    <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
+  </mat-table>
+  <mat-paginator
+    [pageSize]="defaultSearchParameters.DEFAULT_PAGE_SIZE_LOGS"
+    [pageSizeOptions]="defaultSearchParameters.DEFAULT_PAGE_SIZE_OPTIONS"
+    [pageIndex]="(form.value.page || 1) - 1"
+    showFirstLastButtons (page)="changePage($event)"
+    [length]="logs.total">
+  </mat-paginator>
+}

--- a/src/app/components/admin/tab-sections/activity-logs-section/activity-logs-section.component.html
+++ b/src/app/components/admin/tab-sections/activity-logs-section/activity-logs-section.component.html
@@ -5,9 +5,9 @@
 <form [formGroup]="form" class="form">
   <mat-form-field subscriptSizing="dynamic">
     <mat-label>Order by</mat-label>
-    <mat-select formControlName="order">
-      <mat-option value="Ascending">Date (ascending)</mat-option>
-      <mat-option value="Descending">Date (descending)</mat-option>
+    <mat-select [formControl]="form.controls.order">
+      <mat-option [value]="orders[0]">Date (ascending)</mat-option>
+      <mat-option [value]="orders[1]">Date (descending)</mat-option>
     </mat-select>
   </mat-form-field>
 </form>
@@ -33,5 +33,10 @@
   <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
   <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
 </mat-table>
-<mat-paginator [pageSize]="20" [pageSizeOptions]="[5, 10, 15, 20]" [pageIndex]="(form.value.page || 1) - 1" showFirstLastButtons (page)="changePage($event)" [pageSize]="20"
-  [length]="_logs.total"></mat-paginator>
+<mat-paginator
+  [pageSize]="defaultSearchParameters.DEFAULT_PAGE_SIZE_LOGS"
+  [pageSizeOptions]="defaultSearchParameters.DEFAULT_PAGE_SIZE_OPTIONS"
+  [pageIndex]="(form.value.page || 1) - 1"
+  showFirstLastButtons (page)="changePage($event)"
+  [length]="_logs.total">
+</mat-paginator>

--- a/src/app/components/admin/tab-sections/activity-logs-section/activity-logs-section.component.ts
+++ b/src/app/components/admin/tab-sections/activity-logs-section/activity-logs-section.component.ts
@@ -7,7 +7,7 @@ import { debounceTime, distinctUntilChanged, switchMap } from 'rxjs';
 import { IndexedLogsList } from '../../../../services/admin/logs.types';
 import { MatTableModule } from '@angular/material/table';
 import { DatePipe } from '@angular/common';
-import { MatPaginatorModule } from '@angular/material/paginator';
+import { MatPaginatorModule, PageEvent } from '@angular/material/paginator';
 
 @Component({
   selector: 'app-activity-logs-section',
@@ -30,8 +30,15 @@ export class ActivityLogsSectionComponent implements OnInit, OnDestroy {
     this.form.controls.page.setValue(1);
   }
 
-  changePage(page: number) {
-    this.form.controls.page.setValue(page);
+  changePage(pageEvent: PageEvent) {
+    const page = pageEvent.pageIndex + 1;
+    const pageSize = pageEvent.pageSize;
+    this.form.patchValue(
+      {
+        page,
+        pageSize,
+      },
+    );
   }
 
   logs = signal<IndexedLogsList>({
@@ -49,6 +56,7 @@ export class ActivityLogsSectionComponent implements OnInit, OnDestroy {
     {
       page: new FormControl(1),
       order: new FormControl<order>(sorting.order[0]),
+      pageSize: new FormControl(20),
     },
   );
 

--- a/src/app/components/admin/tab-sections/activity-logs-section/activity-logs-section.component.ts
+++ b/src/app/components/admin/tab-sections/activity-logs-section/activity-logs-section.component.ts
@@ -2,12 +2,13 @@ import { ChangeDetectionStrategy, Component, inject, OnInit, signal, OnDestroy }
 import { AdminService } from '../../../../services/admin/admin.service';
 import { MatSelectModule } from '@angular/material/select';
 import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
-import { order, sorting } from '../../../../common/sort';
+import { activityLogsOrderLabels, order, sorting } from '../../../../common/sort';
 import { debounceTime, distinctUntilChanged, switchMap } from 'rxjs';
 import { IndexedLogsList } from '../../../../services/admin/logs.types';
 import { MatTableModule } from '@angular/material/table';
 import { DatePipe } from '@angular/common';
 import { MatPaginatorModule, PageEvent } from '@angular/material/paginator';
+import { defaultSearchValues } from '../../../../common/search';
 
 @Component({
   selector: 'app-activity-logs-section',
@@ -81,4 +82,9 @@ export class ActivityLogsSectionComponent implements OnInit, OnDestroy {
   ngOnDestroy() {
     this._logsSub.unsubscribe();
   }
+
+  protected readonly orders = sorting.order;
+  protected readonly orderLabels = activityLogsOrderLabels;
+
+  protected readonly defaultSearchParameters = defaultSearchValues;
 }

--- a/src/app/components/admin/tab-sections/activity-logs-section/activity-logs-section.component.ts
+++ b/src/app/components/admin/tab-sections/activity-logs-section/activity-logs-section.component.ts
@@ -1,18 +1,19 @@
-import { ChangeDetectionStrategy, Component, inject, OnInit, signal, OnDestroy } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
 import { AdminService } from '../../../../services/admin/admin.service';
 import { MatSelectModule } from '@angular/material/select';
 import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { activityLogsOrderLabels, order, sorting } from '../../../../common/sort';
-import { debounceTime, distinctUntilChanged, switchMap } from 'rxjs';
+import { debounceTime, distinctUntilChanged, startWith, switchMap } from 'rxjs';
 import { IndexedLogsList } from '../../../../services/admin/logs.types';
 import { MatTableModule } from '@angular/material/table';
-import { DatePipe } from '@angular/common';
+import { AsyncPipe, DatePipe } from '@angular/common';
 import { MatPaginatorModule, PageEvent } from '@angular/material/paginator';
 import { defaultSearchValues } from '../../../../common/search';
 
 @Component({
   selector: 'app-activity-logs-section',
   imports: [
+    AsyncPipe,
     ReactiveFormsModule,
     MatSelectModule,
     MatTableModule,
@@ -23,13 +24,9 @@ import { defaultSearchValues } from '../../../../common/search';
   styleUrl: './activity-logs-section.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class ActivityLogsSectionComponent implements OnInit, OnDestroy {
+export class ActivityLogsSectionComponent {
   private readonly adminService = inject(AdminService);
   protected readonly displayedColumns = ['index', 'message', 'date'];
-
-  ngOnInit() {
-    this.form.controls.page.setValue(1);
-  }
 
   changePage(pageEvent: PageEvent) {
     const page = pageEvent.pageIndex + 1;
@@ -42,16 +39,10 @@ export class ActivityLogsSectionComponent implements OnInit, OnDestroy {
     );
   }
 
-  logs = signal<IndexedLogsList>({
+  protected defaultLogs: IndexedLogsList = {
     total: 0,
-    logs: [
-      {
-        index: 0,
-        date: '',
-        message: '',
-      },
-    ],
-  });
+    logs: [],
+  };
 
   protected readonly form = new FormGroup(
     {
@@ -61,7 +52,8 @@ export class ActivityLogsSectionComponent implements OnInit, OnDestroy {
     },
   );
 
-  private _logsSub = this.form.valueChanges.pipe(
+  protected readonly logs$ = this.form.valueChanges.pipe(
+    startWith(this.form.value),
     debounceTime(500),
     distinctUntilChanged(),
     switchMap(() => this.adminService.getActivityLogs(
@@ -70,18 +62,8 @@ export class ActivityLogsSectionComponent implements OnInit, OnDestroy {
         order: this.form.value.order || sorting.order[0],
       },
     )),
-  ).subscribe({
-    next: (logs) => {
-      this.logs.set(logs);
-    },
-    error: () => {
-      //
-    },
-  });
+  );
 
-  ngOnDestroy() {
-    this._logsSub.unsubscribe();
-  }
 
   protected readonly orders = sorting.order;
   protected readonly orderLabels = activityLogsOrderLabels;

--- a/src/app/components/admin/tab-sections/users-tab-section/users-tab-section.component.html
+++ b/src/app/components/admin/tab-sections/users-tab-section/users-tab-section.component.html
@@ -10,7 +10,6 @@
   <mat-form-field subscriptSizing="dynamic">
     <mat-label>Filter by role</mat-label>
     <mat-select multiple [formControl]="form.controls.roles">
-      <mat-option [value]="roles.user">User (all users)</mat-option>
       <mat-option [value]="roles.moderator">Moderator</mat-option>
       <mat-option [value]="roles.admin">Administrator</mat-option>
     </mat-select>
@@ -18,8 +17,8 @@
   <mat-form-field subscriptSizing="dynamic">
     <mat-label>Order by</mat-label>
     <mat-select [formControl]="form.controls.order">
-      <mat-option value="Ascending">Username (ascending)</mat-option>
-      <mat-option value="Descending">Username (descending)</mat-option>
+      <mat-option [value]="orders[0]">Username (ascending)</mat-option>
+      <mat-option [value]="orders[1]">Username (descending)</mat-option>
     </mat-select>
   </mat-form-field>
 </form>
@@ -45,4 +44,11 @@
   <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
   <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
 </mat-table>
-<mat-paginator [pageIndex]="(form.value.page || 1) - 1" showFirstLastButtons (page)="changePage($event.pageIndex + 1)" [pageSize]="20" [length]="_users.total"></mat-paginator>
+<mat-paginator 
+  [pageIndex]="(form.value.page || 1) - 1"
+  showFirstLastButtons
+  (page)="changePage($event)"
+  [pageSize]="defaultSearchParameters.DEFAULT_PAGE_SIZE_USERS"
+  [pageSizeOptions]="defaultSearchParameters.DEFAULT_PAGE_SIZE_OPTIONS"
+  [length]="_users.total">
+</mat-paginator>

--- a/src/app/components/admin/tab-sections/users-tab-section/users-tab-section.component.html
+++ b/src/app/components/admin/tab-sections/users-tab-section/users-tab-section.component.html
@@ -1,54 +1,56 @@
-@let _users = users();
+@let users = users$ | async;
 
-<h2>Manage users</h2>
+@if (users) {
+  <h2>Manage users</h2>
 
-<form [formGroup]="form" class="form">
-  <mat-form-field subscriptSizing="dynamic">
-    <mat-label>Search by username</mat-label>
-    <input matInput [formControl]="form.controls.username" />
-  </mat-form-field>
-  <mat-form-field subscriptSizing="dynamic">
-    <mat-label>Filter by role</mat-label>
-    <mat-select multiple [formControl]="form.controls.roles">
-      <mat-option [value]="roles.moderator">Moderator</mat-option>
-      <mat-option [value]="roles.admin">Administrator</mat-option>
-    </mat-select>
-  </mat-form-field>
-  <mat-form-field subscriptSizing="dynamic">
-    <mat-label>Order by</mat-label>
-    <mat-select [formControl]="form.controls.order">
-      <mat-option [value]="orders[0]">Username (ascending)</mat-option>
-      <mat-option [value]="orders[1]">Username (descending)</mat-option>
-    </mat-select>
-  </mat-form-field>
-</form>
+  <form [formGroup]="form" class="form">
+    <mat-form-field subscriptSizing="dynamic">
+      <mat-label>Search by username</mat-label>
+      <input matInput [formControl]="form.controls.username" />
+    </mat-form-field>
+    <mat-form-field subscriptSizing="dynamic">
+      <mat-label>Filter by role</mat-label>
+      <mat-select multiple [formControl]="form.controls.roles">
+        <mat-option [value]="roles.moderator">Moderator</mat-option>
+        <mat-option [value]="roles.admin">Administrator</mat-option>
+      </mat-select>
+    </mat-form-field>
+    <mat-form-field subscriptSizing="dynamic">
+      <mat-label>Order by</mat-label>
+      <mat-select [formControl]="form.controls.order">
+        <mat-option [value]="orders[0]">Username (ascending)</mat-option>
+        <mat-option [value]="orders[1]">Username (descending)</mat-option>
+      </mat-select>
+    </mat-form-field>
+  </form>
 
-<mat-table [dataSource]="_users.users">
-  <ng-container matColumnDef="username">
-    <th mat-header-cell *matHeaderCellDef>Username</th>
-    <td mat-cell *matCellDef="let user"> <a [routerLink]="['/profile', 'user', user.username]">{{ user.username }}</a> </td>
-  </ng-container>
+  <mat-table [dataSource]="users.users">
+    <ng-container matColumnDef="username">
+      <th mat-header-cell *matHeaderCellDef>Username</th>
+      <td mat-cell *matCellDef="let user"> <a [routerLink]="['/profile', 'user', user.username]">{{ user.username }}</a> </td>
+    </ng-container>
 
-  <ng-container matColumnDef="roles">
-    <th mat-header-cell *matHeaderCellDef>Roles</th>
-    <td mat-cell *matCellDef="let user"> {{ user.roles.join(', ') }} </td>
-  </ng-container>
+    <ng-container matColumnDef="roles">
+      <th mat-header-cell *matHeaderCellDef>Roles</th>
+      <td mat-cell *matCellDef="let user"> {{ user.roles.join(', ') }} </td>
+    </ng-container>
 
-  <ng-container matColumnDef="actions">
-    <th mat-header-cell *matHeaderCellDef>Actions</th>
-    <td mat-cell *matCellDef="let user" class="actions">
-      <app-role-change-select (select)="changeRole($event, user.id)" [roles]="user.roles"></app-role-change-select>
-    </td>
-  </ng-container>
+    <ng-container matColumnDef="actions">
+      <th mat-header-cell *matHeaderCellDef>Actions</th>
+      <td mat-cell *matCellDef="let user" class="actions">
+        <app-role-change-select (select)="changeRole($event, user.id)" [roles]="user.roles"></app-role-change-select>
+      </td>
+    </ng-container>
 
-  <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
-  <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
-</mat-table>
-<mat-paginator 
-  [pageIndex]="(form.value.page || 1) - 1"
-  showFirstLastButtons
-  (page)="changePage($event)"
-  [pageSize]="defaultSearchParameters.DEFAULT_PAGE_SIZE_USERS"
-  [pageSizeOptions]="defaultSearchParameters.DEFAULT_PAGE_SIZE_OPTIONS"
-  [length]="_users.total">
-</mat-paginator>
+    <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+    <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
+  </mat-table>
+  <mat-paginator 
+    [pageIndex]="(form.value.page || 1) - 1"
+    showFirstLastButtons
+    (page)="changePage($event)"
+    [pageSize]="defaultSearchParameters.DEFAULT_PAGE_SIZE_USERS"
+    [pageSizeOptions]="defaultSearchParameters.DEFAULT_PAGE_SIZE_OPTIONS"
+    [length]="users.total">
+  </mat-paginator>
+}

--- a/src/app/components/admin/tab-sections/users-tab-section/users-tab-section.component.html
+++ b/src/app/components/admin/tab-sections/users-tab-section/users-tab-section.component.html
@@ -5,11 +5,11 @@
 <form [formGroup]="form" class="form">
   <mat-form-field subscriptSizing="dynamic">
     <mat-label>Search by username</mat-label>
-    <input matInput formControlName="username" />
+    <input matInput [formControl]="form.controls.username" />
   </mat-form-field>
   <mat-form-field subscriptSizing="dynamic">
     <mat-label>Filter by role</mat-label>
-    <mat-select formControlName="role">
+    <mat-select multiple [formControl]="form.controls.roles">
       <mat-option [value]="roles.user">User (all users)</mat-option>
       <mat-option [value]="roles.moderator">Moderator</mat-option>
       <mat-option [value]="roles.admin">Administrator</mat-option>
@@ -17,9 +17,9 @@
   </mat-form-field>
   <mat-form-field subscriptSizing="dynamic">
     <mat-label>Order by</mat-label>
-    <mat-select formControlName="order">
-      <mat-option value="asc">Username (ascending)</mat-option>
-      <mat-option value="desc">Username (descending)</mat-option>
+    <mat-select [formControl]="form.controls.order">
+      <mat-option value="Ascending">Username (ascending)</mat-option>
+      <mat-option value="Descending">Username (descending)</mat-option>
     </mat-select>
   </mat-form-field>
 </form>

--- a/src/app/components/admin/tab-sections/users-tab-section/users-tab-section.component.spec.ts
+++ b/src/app/components/admin/tab-sections/users-tab-section/users-tab-section.component.spec.ts
@@ -1,7 +1,6 @@
 import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
 
 import { UsersTabSectionComponent } from './users-tab-section.component';
-import { AdminService } from '../../../../services/admin/admin.service';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { Observable, of } from 'rxjs';
 import { UserList } from '../../../../services/admin/searchTable.types';
@@ -13,9 +12,10 @@ import { MatPaginatorHarness } from '@angular/material/paginator/testing';
 import { HarnessLoader } from '@angular/cdk/testing';
 import { provideHttpClient } from '@angular/common/http';
 import { provideHttpClientTesting } from '@angular/common/http/testing';
-import { SearchOptionsWithPaginationAndOrdering } from '../../../../types/search';
+import { SearchProfilesParameters } from '../../../../types/search';
 import { MatSelectHarness } from '@angular/material/select/testing';
 import { provideRouter } from '@angular/router';
+import { ProfileService } from '../../../../services/profile/profile.service';
 
 const mockUserData: UserList = {
   total: 21,
@@ -131,10 +131,10 @@ const mockUserData: UserList = {
 describe('UsersTabSectionComponent', () => {
   let component: UsersTabSectionComponent;
   let fixture: ComponentFixture<UsersTabSectionComponent>;
-  let adminService: AdminService;
+  let profileService: ProfileService;
   let loader: HarnessLoader;
 
-  let spy: jasmine.Spy<(role: string, username: string, options: SearchOptionsWithPaginationAndOrdering) => Observable<UserList>>;
+  let spy: jasmine.Spy<(options: SearchProfilesParameters) => Observable<UserList>>;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
@@ -146,8 +146,8 @@ describe('UsersTabSectionComponent', () => {
     fixture = TestBed.createComponent(UsersTabSectionComponent);
     loader = TestbedHarnessEnvironment.loader(fixture);
     component = fixture.componentInstance;
-    adminService = TestBed.inject(AdminService);
-    spy = spyOn(adminService, 'getUsersOfRole').and.returnValue(of({...mockUserData, users: mockUserData.users.filter((_, i) => i < 20)}));
+    profileService = TestBed.inject(ProfileService);
+    spy = spyOn(profileService, 'searchProfiles').and.returnValue(of({...mockUserData, users: mockUserData.users.filter((_, i) => i < 20)}));
     fixture.detectChanges();
   });
 

--- a/src/app/components/admin/tab-sections/users-tab-section/users-tab-section.component.ts
+++ b/src/app/components/admin/tab-sections/users-tab-section/users-tab-section.component.ts
@@ -1,9 +1,8 @@
-import { ChangeDetectionStrategy, Component, inject, OnDestroy, signal, OnInit } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject, OnDestroy, OnInit } from '@angular/core';
 import { MatTableModule } from '@angular/material/table';
 import { AdminService } from '../../../../services/admin/admin.service';
 import { debounceTime, distinctUntilChanged, startWith, Subscription, switchMap, tap } from 'rxjs';
 import { role, roles } from '../../../../common/roles';
-import { UserList } from '../../../../services/admin/searchTable.types';
 import { MatPaginatorModule, PageEvent } from '@angular/material/paginator';
 import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { order, sorting } from '../../../../common/sort';
@@ -39,7 +38,6 @@ export class UsersTabSectionComponent implements OnDestroy, OnInit {
   protected displayedColumns = ['username', 'roles', 'actions'];
   protected readonly roles = roles;
 
-  readonly username = new FormControl('');
   readonly form = new FormGroup(
     {
       username: new FormControl(''),
@@ -66,10 +64,6 @@ export class UsersTabSectionComponent implements OnDestroy, OnInit {
     this.form.controls.username.setValue('');
   }
 
-  users = signal<UserList>({
-    total: 0,
-    users: [],
-  });
 
   changePage(pageEvent: PageEvent) {
     const page = pageEvent.pageIndex + 1;
@@ -78,7 +72,6 @@ export class UsersTabSectionComponent implements OnDestroy, OnInit {
   }
 
   ngOnDestroy() {
-    this._usersSub.unsubscribe();
     this._promoteSub?.unsubscribe();
     this._demoteSub?.unsubscribe();
   }
@@ -96,23 +89,6 @@ export class UsersTabSectionComponent implements OnDestroy, OnInit {
     })),
   );
 
-  private _usersSub = this.form.valueChanges.pipe(
-    debounceTime(500),
-    distinctUntilChanged(),
-    switchMap(() => this.profileService.searchProfiles({
-      page: this.form.value.page || 1,
-      pageSize: this.form.value.pageSize || 20,
-      order: this.form.value.order || 'Ascending',
-      roles: this.form.value.roles || [roles.user],
-      username: this.form.value.username || '',
-    }))).subscribe({
-      next: (v) => {
-        this.users.set(v);
-      },
-      error() {
-//
-      },
-    });
 
     private promote(role: role, userId: string) {
       this._promoteSub = this.adminService.addRoleToUser(userId, role)

--- a/src/app/components/admin/tab-sections/users-tab-section/users-tab-section.component.ts
+++ b/src/app/components/admin/tab-sections/users-tab-section/users-tab-section.component.ts
@@ -38,7 +38,7 @@ export class UsersTabSectionComponent implements OnDestroy, OnInit {
     {
       username: new FormControl(''),
       page: new FormControl(1),
-      order: new FormControl('asc' as order),
+      order: new FormControl('Ascending' as order),
       role: new FormControl(roles.user as role),
     },
   );
@@ -78,7 +78,7 @@ export class UsersTabSectionComponent implements OnDestroy, OnInit {
     debounceTime(500),
     distinctUntilChanged(),
     switchMap(() => this.adminService.getUsersOfRole(this.form.value.role || roles.user, this.form.value.username || '', {
-      order: this.form.value.order || 'asc',
+      order: this.form.value.order || 'Ascending',
       page: this.form.value.page || 1,
     }))).subscribe({
       next: (v) => {
@@ -98,7 +98,7 @@ export class UsersTabSectionComponent implements OnDestroy, OnInit {
             {
               page: 1,
               username: '',
-              order: 'asc',
+              order: 'Ascending',
               role: roles.user,
             },
           );
@@ -114,7 +114,7 @@ export class UsersTabSectionComponent implements OnDestroy, OnInit {
             {
               page: 1,
               username: '',
-              order: 'asc',
+              order: 'Ascending',
               role: roles.user,
             },
           );

--- a/src/app/components/admin/tab-sections/users-tab-section/users-tab-section.component.ts
+++ b/src/app/components/admin/tab-sections/users-tab-section/users-tab-section.component.ts
@@ -4,15 +4,16 @@ import { AdminService } from '../../../../services/admin/admin.service';
 import { debounceTime, distinctUntilChanged, Subscription, switchMap, tap } from 'rxjs';
 import { role, roles } from '../../../../common/roles';
 import { UserList } from '../../../../services/admin/searchTable.types';
-import { MatPaginatorModule } from '@angular/material/paginator';
+import { MatPaginatorModule, PageEvent } from '@angular/material/paginator';
 import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
-import { order } from '../../../../common/sort';
+import { order, sorting } from '../../../../common/sort';
 import { MatInputModule } from '@angular/material/input';
 import { MatSelectModule } from '@angular/material/select';
 import { RoleChangeSelectComponent } from '../../../common/role-change-select/role-change-select.component';
 import { RoleChangeSelectEvent, RoleChangeSelectEventType } from '../../../common/role-change-select/types';
 import { RouterModule } from '@angular/router';
 import { ProfileService } from '../../../../services/profile/profile.service';
+import { defaultSearchValues } from '../../../../common/search';
 
 @Component({
   selector: 'app-users-tab-section',
@@ -68,8 +69,10 @@ export class UsersTabSectionComponent implements OnDestroy, OnInit {
     users: [],
   });
 
-  changePage(page: number) {
-    this.form.controls.page.setValue(page);
+  changePage(pageEvent: PageEvent) {
+    const page = pageEvent.pageIndex + 1;
+    const pageSize = pageEvent.pageSize;
+    this.form.patchValue({ page, pageSize });
   }
 
   ngOnDestroy() {
@@ -114,4 +117,7 @@ export class UsersTabSectionComponent implements OnDestroy, OnInit {
 
     private _promoteSub?: Subscription;
     private _demoteSub?: Subscription;
+
+    protected readonly orders = sorting.order;
+    protected readonly defaultSearchParameters = defaultSearchValues;
 }

--- a/src/app/components/admin/tab-sections/users-tab-section/users-tab-section.component.ts
+++ b/src/app/components/admin/tab-sections/users-tab-section/users-tab-section.component.ts
@@ -12,6 +12,7 @@ import { MatSelectModule } from '@angular/material/select';
 import { RoleChangeSelectComponent } from '../../../common/role-change-select/role-change-select.component';
 import { RoleChangeSelectEvent, RoleChangeSelectEventType } from '../../../common/role-change-select/types';
 import { RouterModule } from '@angular/router';
+import { ProfileService } from '../../../../services/profile/profile.service';
 
 @Component({
   selector: 'app-users-tab-section',
@@ -30,6 +31,8 @@ import { RouterModule } from '@angular/router';
 })
 export class UsersTabSectionComponent implements OnDestroy, OnInit {
   private readonly adminService = inject(AdminService);
+  private readonly profileService = inject(ProfileService);
+
   protected displayedColumns = ['username', 'roles', 'actions'];
   protected readonly roles = roles;
 
@@ -39,7 +42,8 @@ export class UsersTabSectionComponent implements OnDestroy, OnInit {
       username: new FormControl(''),
       page: new FormControl(1),
       order: new FormControl('Ascending' as order),
-      role: new FormControl(roles.user as role),
+      roles: new FormControl([roles.user] as role[]),
+      pageSize: new FormControl(20),
     },
   );
 
@@ -77,9 +81,12 @@ export class UsersTabSectionComponent implements OnDestroy, OnInit {
   private _usersSub = this.form.valueChanges.pipe(
     debounceTime(500),
     distinctUntilChanged(),
-    switchMap(() => this.adminService.getUsersOfRole(this.form.value.role || roles.user, this.form.value.username || '', {
-      order: this.form.value.order || 'Ascending',
+    switchMap(() => this.profileService.searchProfiles({
       page: this.form.value.page || 1,
+      pageSize: this.form.value.pageSize || 20,
+      order: this.form.value.order || 'Ascending',
+      roles: this.form.value.roles || [roles.user],
+      username: this.form.value.username || '',
     }))).subscribe({
       next: (v) => {
         this.users.set(v);
@@ -99,7 +106,8 @@ export class UsersTabSectionComponent implements OnDestroy, OnInit {
               page: 1,
               username: '',
               order: 'Ascending',
-              role: roles.user,
+              roles: [roles.user],
+              pageSize: 20,
             },
           );
         },
@@ -115,7 +123,8 @@ export class UsersTabSectionComponent implements OnDestroy, OnInit {
               page: 1,
               username: '',
               order: 'Ascending',
-              role: roles.user,
+              roles: [roles.user],
+              pageSize: 20,
             },
           );
         },

--- a/src/app/components/admin/tab-sections/users-tab-section/users-tab-section.component.ts
+++ b/src/app/components/admin/tab-sections/users-tab-section/users-tab-section.component.ts
@@ -1,7 +1,7 @@
 import { ChangeDetectionStrategy, Component, inject, OnDestroy, signal, OnInit } from '@angular/core';
 import { MatTableModule } from '@angular/material/table';
 import { AdminService } from '../../../../services/admin/admin.service';
-import { debounceTime, distinctUntilChanged, Subscription, switchMap } from 'rxjs';
+import { debounceTime, distinctUntilChanged, Subscription, switchMap, tap } from 'rxjs';
 import { role, roles } from '../../../../common/roles';
 import { UserList } from '../../../../services/admin/searchTable.types';
 import { MatPaginatorModule } from '@angular/material/paginator';
@@ -96,39 +96,20 @@ export class UsersTabSectionComponent implements OnDestroy, OnInit {
       },
     });
 
-
     private promote(role: role, userId: string) {
-      this._promoteSub = this.adminService.addRoleToUser(userId, role).subscribe({
-        next: v => {
-          this.users.set(v);
-          this.form.setValue(
-            {
-              page: 1,
-              username: '',
-              order: 'Ascending',
-              roles: [roles.user],
-              pageSize: 20,
-            },
-          );
-        },
-      });
+      this._promoteSub = this.adminService.addRoleToUser(userId, role)
+      .pipe(
+        // trigger a "refresh"
+        tap(() => this.form.patchValue({ username: this.form.value.username })),
+      ).subscribe();
     }
 
     private demote(role: role, userId: string) {
-      this._demoteSub = this.adminService.removeRoleFromUser(userId, role).subscribe({
-        next: v => {
-          this.users.set(v);
-          this.form.setValue(
-            {
-              page: 1,
-              username: '',
-              order: 'Ascending',
-              roles: [roles.user],
-              pageSize: 20,
-            },
-          );
-        },
-      });
+      this._demoteSub = this.adminService.removeRoleFromUser(userId, role)
+      .pipe(
+        // trigger a "refresh"
+        tap(() => this.form.patchValue({ username: this.form.value.username })),
+      ).subscribe();
     }
 
     private _promoteSub?: Subscription;

--- a/src/app/components/common/role-change-select/role-change-select.component.ts
+++ b/src/app/components/common/role-change-select/role-change-select.component.ts
@@ -1,5 +1,5 @@
 import { Component, model, output } from '@angular/core';
-import { role, roles as commonRoles } from '../../../common/roles';
+import { role, rolesThatCanBeGivenOrRemoved } from '../../../common/roles';
 import { MatSelectModule } from '@angular/material/select';
 import { RoleChangeSelectEvent, RoleChangeSelectEventType } from './types';
 import { MatOptionSelectionChange } from '@angular/material/core';
@@ -14,7 +14,7 @@ export class RoleChangeSelectComponent {
   roles = model.required<role[]>();
   select = output<RoleChangeSelectEvent>();
 
-  protected readonly rolesList = Object.values(commonRoles).filter(role => role !== commonRoles.user && role !== commonRoles.admin);
+  protected readonly rolesList = rolesThatCanBeGivenOrRemoved;
 
   change(event: MatOptionSelectionChange) {
     if (!event.isUserInput) return;

--- a/src/app/components/profile/user-quizzes-list/user-quizzes-list.component.html
+++ b/src/app/components/profile/user-quizzes-list/user-quizzes-list.component.html
@@ -1,7 +1,11 @@
 @let _user = user();
 @let username = _user.username;
-<app-search-results [quizList]="quizList()" [routeToNavigate]="['profile', 'user', username]">
+@let results = searchResults$ | async;
+
+@if (results) {
+<app-search-results [quizList]="results" [routeToNavigate]="['profile', 'user', username]">
   <section search-results-title>
     <h2><i>{{ username }}</i>'s quizzes</h2>
   </section>
 </app-search-results>
+}

--- a/src/app/components/profile/user-quizzes-list/user-quizzes-list.component.ts
+++ b/src/app/components/profile/user-quizzes-list/user-quizzes-list.component.ts
@@ -1,24 +1,28 @@
-import { ChangeDetectionStrategy, Component, inject, input, OnInit, OnDestroy, signal } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject, input } from '@angular/core';
 import { UserState } from '../../../store/user/user.store';
 import { SearchResultsService } from '../../../services/search-results/search-results.service';
 import { QuizService } from '../../../services/quiz/quiz.service';
-import { combineLatest, filter, map, Subscription, switchMap } from 'rxjs';
+import { combineLatest, filter, map, switchMap } from 'rxjs';
 import { toObservable } from '@angular/core/rxjs-interop';
-import { QuizList } from '../../../services/quiz/types';
 import { SearchResultsComponent } from '../../search/search-results/search-results.component';
+import { AsyncPipe } from '@angular/common';
 
 @Component({
   selector: 'app-user-quizzes-list',
-  imports: [SearchResultsComponent],
+  imports: [
+    AsyncPipe,
+    SearchResultsComponent,
+  ],
   templateUrl: './user-quizzes-list.component.html',
   styleUrl: './user-quizzes-list.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class UserQuizzesListComponent implements OnInit, OnDestroy {
+export class UserQuizzesListComponent {
   user = input.required<UserState>();
   private readonly user$ = toObservable(this.user);
   private readonly searchResults = inject(SearchResultsService);
   private readonly quizService = inject(QuizService);
+
   private readonly searchParams$ = combineLatest(
     [this.user$, this.searchResults.searchOptions$],
   ).pipe(map(value => (
@@ -28,32 +32,11 @@ export class UserQuizzesListComponent implements OnInit, OnDestroy {
     }
   )));
 
-  _searchSub?: Subscription;
-
-  readonly quizList = signal<QuizList>(
-    {
-      total: 0,
-      quizzes: [],
-    },
-  );
-
-  ngOnInit() {
-    this._searchSub = this.searchParams$
-      .pipe(
+  protected readonly searchResults$ = this.searchParams$
+    .pipe(
         filter(value => value.user.id !== ''),
-        switchMap(value => this.quizService.search({...value.search, author: value.user.username})),
-      )
-      .subscribe({
-        next: (value) => {
-          this.quizList.set(value);
-        },
-        error() {
-          //
-        },
-      });
-  }
-
-  ngOnDestroy() {
-    this._searchSub?.unsubscribe();
-  }
+        switchMap(
+          value => this.quizService.search({...value.search, author: value.user.username}),
+        ),
+    );
 }

--- a/src/app/components/profile/user-quizzes-list/user-quizzes-list.component.ts
+++ b/src/app/components/profile/user-quizzes-list/user-quizzes-list.component.ts
@@ -41,7 +41,7 @@ export class UserQuizzesListComponent implements OnInit, OnDestroy {
     this._searchSub = this.searchParams$
       .pipe(
         filter(value => value.user.id !== ''),
-        switchMap(value => this.quizService.getUserQuizzes(value.user.id, value.search)),
+        switchMap(value => this.quizService.search({...value.search, author: value.user.username})),
       )
       .subscribe({
         next: (value) => {

--- a/src/app/components/search/search-quiz-sorter/search-quiz-sorter.component.spec.ts
+++ b/src/app/components/search/search-quiz-sorter/search-quiz-sorter.component.spec.ts
@@ -30,7 +30,7 @@ describe('SearchQuizSorterComponent', () => {
 
   it('Correctly reflects the current value when it is set from the outside', async () => {
     fixture.componentRef.setInput('sortOptions', {
-      sort: sorting.categories[1],
+      sortBy: sorting.categories[1],
       order: sorting.order[1],
     });
 
@@ -44,7 +44,7 @@ describe('SearchQuizSorterComponent', () => {
     expect(await options[3].isSelected()).toBeTrue();
 
     fixture.componentRef.setInput('sortOptions', {
-      sort: sorting.categories[0],
+      sortBy: sorting.categories[0],
       order: sorting.order[0],
     });
 

--- a/src/app/components/search/search-quiz-sorter/search-quiz-sorter.component.spec.ts
+++ b/src/app/components/search/search-quiz-sorter/search-quiz-sorter.component.spec.ts
@@ -64,7 +64,7 @@ describe('SearchQuizSorterComponent', () => {
 
     expect(spy).toHaveBeenCalledWith(
       {
-        sort: sorting.categories[0],
+        sortBy: sorting.categories[0],
         order: sorting.order[1],
       },
     );

--- a/src/app/components/search/search-quiz-sorter/search-quiz-sorter.component.ts
+++ b/src/app/components/search/search-quiz-sorter/search-quiz-sorter.component.ts
@@ -14,7 +14,7 @@ export class SearchQuizSorterComponent {
 
   readonly sortOptions = input<SortAndOrder>(
     {
-      sort: sorting.categories[0],
+      sortBy: sorting.categories[0],
       order: sorting.order[0],
     },
   );
@@ -23,15 +23,15 @@ export class SearchQuizSorterComponent {
 
   protected readonly selectedValue = computed(() => {
     const options = this.sortOptions();
-    const { sort, order } = options;
-    return `${sort}-${order}`;
+    const { sortBy, order } = options;
+    return `${sortBy}-${order}`;
   });
 
   updateSorting(value: string) {
-    const sort = this._extractSortCategory(value);
+    const sortBy = this._extractSortCategory(value);
     const order = this._extractOrder(value);
 
-    this.select.emit({ sort, order });
+    this.select.emit({ sortBy, order });
   }
 
   private _extractSortCategory(value: string) {

--- a/src/app/components/search/search-results/search-results.component.html
+++ b/src/app/components/search/search-results/search-results.component.html
@@ -1,7 +1,8 @@
 @let searchOptions = searchOptions$ | async;
-@let order = searchOptions?.order || 'asc';
-@let sort = searchOptions?.sort || 'title';
+@let order = searchOptions?.order || 'Ascending';
+@let sortBy = searchOptions?.sortBy || 'Title';
 @let page = searchOptions?.page || 1;
+@let pageSize = searchOptions?.pageSize || 5;
 
 @let _quizzes = quizzes();
 @let total = totalQuizzes();
@@ -9,7 +10,7 @@
 <ng-content select="[search-results-title]" />
 
 <div class="search-results-section">
-  <app-search-quiz-sorter (select)="search($event)" [sortOptions]="{ sort, order }" />
+  <app-search-quiz-sorter (select)="search($event)" [sortOptions]="{ sortBy, order }" />
 
   @if (_quizzes.length === 0) {
   <p class="no-quizzes">No quizzes found, try changing your search parameters and try again!</p>
@@ -21,5 +22,5 @@
   </div>
   }
 
-  <mat-paginator [pageSize]="6" [length]="total" [pageIndex]="page - 1" (page)="paginate($event.pageIndex + 1)" />
+  <mat-paginator [pageSize]="pageSize" [pageSizeOptions]="[5, 10, 15, 20]" [length]="total" [pageIndex]="page - 1" (page)="paginate($event)" />
 </div>

--- a/src/app/components/search/search-results/search-results.component.html
+++ b/src/app/components/search/search-results/search-results.component.html
@@ -1,8 +1,8 @@
 @let searchOptions = searchOptions$ | async;
-@let order = searchOptions?.order || 'Ascending';
-@let sortBy = searchOptions?.sortBy || 'Title';
+@let order = searchOptions?.order || defaultSearchValues.DEFAULT_ORDER;
+@let sortBy = searchOptions?.sortBy || defaultSearchValues.DEFAULT_QUIZ_SORT_CATEGORY;
 @let page = searchOptions?.page || 1;
-@let pageSize = searchOptions?.pageSize || 5;
+@let pageSize = searchOptions?.pageSize || defaultSearchValues.DEFAULT_PAGE_SIZE_QUIZ;
 
 @let _quizzes = quizzes();
 @let total = totalQuizzes();
@@ -22,5 +22,6 @@
   </div>
   }
 
-  <mat-paginator [pageSize]="pageSize" [pageSizeOptions]="[5, 10, 15, 20]" [length]="total" [pageIndex]="page - 1" (page)="paginate($event)" />
+  <mat-paginator [pageSize]="pageSize" [pageSizeOptions]="defaultSearchValues.DEFAULT_PAGE_SIZE_OPTIONS"
+    [length]="total" [pageIndex]="page - 1" (page)="paginate($event)" />
 </div>

--- a/src/app/components/search/search-results/search-results.component.spec.ts
+++ b/src/app/components/search/search-results/search-results.component.spec.ts
@@ -71,7 +71,7 @@ describe('SearchResultsComponent', () => {
 
     const params = activatedRoute.snapshot.queryParams;
 
-    expect(params['sort']).toBe(sorting.categories[0]);
+    expect(params['sortBy']).toBe(sorting.categories[0]);
     expect(params['order']).toBe(sorting.order[1]);
   });
 

--- a/src/app/components/search/search-results/search-results.component.ts
+++ b/src/app/components/search/search-results/search-results.component.ts
@@ -3,7 +3,7 @@ import { Router } from '@angular/router';
 import { SortAndOrder } from '../../../common/sort';
 import { SearchQuizSorterComponent } from '../search-quiz-sorter/search-quiz-sorter.component';
 import { AsyncPipe } from '@angular/common';
-import { MatPaginatorModule } from '@angular/material/paginator';
+import { MatPaginatorModule, PageEvent } from '@angular/material/paginator';
 import { SearchResultsService } from '../../../services/search-results/search-results.service';
 import { QuizList } from '../../../services/quiz/types';
 import { SearchResultCardComponent } from '../search-result-card/search-result-card.component';
@@ -32,9 +32,12 @@ export class SearchResultsComponent {
     });
   }
 
-  paginate(page: number) {
+  paginate(event: PageEvent) {
+    const page = event.pageIndex + 1;
+    const pageSize = event.pageSize;
+
     this.router.navigate(this.routeToNavigate(), {
-      queryParams: { page },
+      queryParams: { page, pageSize },
       queryParamsHandling: 'merge',
     });
   }

--- a/src/app/components/search/search-results/search-results.component.ts
+++ b/src/app/components/search/search-results/search-results.component.ts
@@ -7,6 +7,7 @@ import { MatPaginatorModule, PageEvent } from '@angular/material/paginator';
 import { SearchResultsService } from '../../../services/search-results/search-results.service';
 import { QuizList } from '../../../services/quiz/types';
 import { SearchResultCardComponent } from '../search-result-card/search-result-card.component';
+import { defaultSearchValues } from '../../../common/search';
 
 @Component({
   selector: 'app-search-results',
@@ -43,4 +44,5 @@ export class SearchResultsComponent {
   }
 
   protected readonly searchOptions$ = this.searchResults.searchOptions$;
+  protected readonly defaultSearchValues = defaultSearchValues;
 }

--- a/src/app/pages/profile/profile.component.ts
+++ b/src/app/pages/profile/profile.component.ts
@@ -3,7 +3,6 @@ import { MatIconModule } from '@angular/material/icon';
 import { MatTabsModule } from '@angular/material/tabs';
 import { UserState } from '../../store/user/user.store';
 import { Subscription } from 'rxjs';
-import { AuthService } from '../../services/auth/auth.service';
 import { ProfileOverviewComponent } from '../../components/profile/profile-overview/profile-overview.component';
 import { UserQuizzesListComponent } from '../../components/profile/user-quizzes-list/user-quizzes-list.component';
 import { Title } from '@angular/platform-browser';
@@ -23,7 +22,6 @@ import { ProfileService } from '../../services/profile/profile.service';
 })
 export class ProfileComponent implements OnInit, OnDestroy {
   username = input.required<string>();
-  private readonly authService = inject(AuthService);
   private readonly profileService = inject(ProfileService);
   private readonly title = inject(Title);
 

--- a/src/app/pages/profile/profile.component.ts
+++ b/src/app/pages/profile/profile.component.ts
@@ -7,6 +7,7 @@ import { AuthService } from '../../services/auth/auth.service';
 import { ProfileOverviewComponent } from '../../components/profile/profile-overview/profile-overview.component';
 import { UserQuizzesListComponent } from '../../components/profile/user-quizzes-list/user-quizzes-list.component';
 import { Title } from '@angular/platform-browser';
+import { ProfileService } from '../../services/profile/profile.service';
 
 @Component({
   selector: 'app-profile',
@@ -23,6 +24,7 @@ import { Title } from '@angular/platform-browser';
 export class ProfileComponent implements OnInit, OnDestroy {
   username = input.required<string>();
   private readonly authService = inject(AuthService);
+  private readonly profileService = inject(ProfileService);
   private readonly title = inject(Title);
 
   user = signal<UserState>(
@@ -34,7 +36,7 @@ export class ProfileComponent implements OnInit, OnDestroy {
   );
 
   ngOnInit() {
-    this._profileSub = this.authService.getProfileByUsername(this.username())
+    this._profileSub = this.profileService.getProfileByUsername(this.username())
       .subscribe({
         next: (user) => {
           this.user.set(user);

--- a/src/app/pages/quiz/all-page/all-page.component.html
+++ b/src/app/pages/quiz/all-page/all-page.component.html
@@ -1,3 +1,7 @@
-<app-search-results [routeToNavigate]="['quiz', 'all']" [quizList]="quizList()">
+@let results = results$ | async;
+
+@if (results) {
+  <app-search-results [routeToNavigate]="['quiz', 'all']" [quizList]="results">
   <h1 search-results-title>Browse all quizzes</h1>
 </app-search-results>
+}

--- a/src/app/pages/quiz/all-page/all-page.component.ts
+++ b/src/app/pages/quiz/all-page/all-page.component.ts
@@ -1,49 +1,30 @@
-import { ChangeDetectionStrategy, Component, inject, OnDestroy, OnInit, signal } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
 import { SearchResultsComponent } from '../../../components/search/search-results/search-results.component';
 import { QuizService } from '../../../services/quiz/quiz.service';
 import { SearchResultsService } from '../../../services/search-results/search-results.service';
-import { Subscription, switchMap } from 'rxjs';
-import { QuizList } from '../../../services/quiz/types';
+import { switchMap } from 'rxjs';
+import { AsyncPipe } from '@angular/common';
 
 @Component({
   selector: 'app-all-page',
-  imports: [SearchResultsComponent],
+  imports: [
+    AsyncPipe,
+    SearchResultsComponent,
+  ],
   templateUrl: './all-page.component.html',
   styleUrl: './all-page.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class AllPageComponent implements OnDestroy, OnInit {
+export class AllPageComponent {
   private readonly quizService = inject(QuizService);
   private readonly searchResults = inject(SearchResultsService);
 
-  quizList = signal<QuizList>(
-    {
-      total: 0,
-      quizzes: [],
-    },
-  );
-
-  ngOnInit() {
-    this.searchResultsSub = this.searchResults.searchOptions$.pipe(
+  protected readonly results$ = this.searchResults.searchOptions$
+    .pipe(
       switchMap((params) => (
         this.quizService.search(params)
       )),
-    ).subscribe({
-      next: (value) => {
-        this.quizList.set(value);
-      },
-      error() {
-        //
-      },
-    });
-
-  }
-
-  ngOnDestroy() {
-    this.searchResultsSub?.unsubscribe();
-  }
-
-  searchResultsSub?: Subscription;
+  );
 }
 
 

--- a/src/app/pages/quiz/all-page/all-page.component.ts
+++ b/src/app/pages/quiz/all-page/all-page.component.ts
@@ -26,7 +26,7 @@ export class AllPageComponent implements OnDestroy, OnInit {
   ngOnInit() {
     this.searchResultsSub = this.searchResults.searchOptions$.pipe(
       switchMap((params) => (
-        this.quizService.getAllQuizzes(params)
+        this.quizService.search(params)
       )),
     ).subscribe({
       next: (value) => {

--- a/src/app/pages/quiz/search-page/search-page.component.html
+++ b/src/app/pages/quiz/search-page/search-page.component.html
@@ -1,5 +1,8 @@
 @let query = searchQuery | async;
+@let results = searchResults$ | async;
 
-<app-search-results [routeToNavigate]="['quiz', 'search']" [quizList]="quizList()">
-  <h1 search-results-title>Search results for "{{ query }}"</h1>
+@if (results) {
+<app-search-results [routeToNavigate]="['quiz', 'search']" [quizList]="results">
+    <h1 search-results-title>Search results for "{{ query }}"</h1>
 </app-search-results>
+}

--- a/src/app/pages/quiz/search-page/search-page.component.ts
+++ b/src/app/pages/quiz/search-page/search-page.component.ts
@@ -46,7 +46,7 @@ export class SearchPageComponent implements OnDestroy, OnInit {
   ngOnInit() {
     this.searchResultsSub = this.searchParams.pipe(
       switchMap((params) => (
-        this.quizService.getQuizzesByTitle(params.search, {...params })
+        this.quizService.search({...params, title: params.search })
       )),
     ).subscribe({
       next: (value) => {

--- a/src/app/pages/quiz/search-page/search-page.component.ts
+++ b/src/app/pages/quiz/search-page/search-page.component.ts
@@ -1,11 +1,10 @@
 import { AsyncPipe } from '@angular/common';
-import { ChangeDetectionStrategy, Component, inject, OnDestroy, OnInit, signal } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject, OnDestroy, OnInit } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { combineLatest, map, Subscription, switchMap } from 'rxjs';
 import { SearchResultsComponent } from '../../../components/search/search-results/search-results.component';
 import { SearchResultsService } from '../../../services/search-results/search-results.service';
 import { QuizService } from '../../../services/quiz/quiz.service';
-import { QuizList } from '../../../services/quiz/types';
 import { Title } from '@angular/platform-browser';
 
 @Component({
@@ -29,13 +28,6 @@ export class SearchPageComponent implements OnDestroy, OnInit {
     map(qp => qp.get('query') || ''),
   );
 
-  quizList = signal<QuizList>(
-    {
-      total: 0,
-      quizzes: [],
-    },
-  );
-
   private readonly searchParams = combineLatest([this.searchQuery, this.searchResults.searchOptions$])
     .pipe(
       map(value => (
@@ -43,30 +35,22 @@ export class SearchPageComponent implements OnDestroy, OnInit {
       ),
   ));
 
-  ngOnInit() {
-    this.searchResultsSub = this.searchParams.pipe(
+  protected readonly searchResults$ = this.searchParams
+    .pipe(
       switchMap((params) => (
         this.quizService.search({...params, title: params.search })
       )),
-    ).subscribe({
-      next: (value) => {
-        this.quizList.set(value);
-      },
-      error() {
-        //
-      },
-    });
+    );
 
+  ngOnInit() {
     this.searchQuerySub = this.searchQuery.subscribe(query => {
       this.title.setTitle(`Search results for "${query}" | Quiz World`);
     });
   }
 
   ngOnDestroy() {
-    this.searchResultsSub?.unsubscribe();
     this.searchQuerySub?.unsubscribe();
   }
 
-  searchResultsSub?: Subscription;
   searchQuerySub?: Subscription;
 }

--- a/src/app/services/admin/admin.service.ts
+++ b/src/app/services/admin/admin.service.ts
@@ -16,12 +16,6 @@ export class AdminService {
   readonly rolesUrl = api.endpoints.roles;
   readonly logsUrl = api.endpoints.logs;
 
-  getUsersOfRole(role: string, username: string, options: SearchOptionsWithPaginationAndOrdering) {
-    const params = paramsBuilder({ ...options, username });
-
-    return this.http.get<UserList>(this.rolesUrl.getUsersOfRole(role), { params });
-  }
-
   getUsersByUsername(username: string, options?: SearchOptionsWithPaginationAndOrdering) {
     const params = paramsBuilder({ ...options, username });
 

--- a/src/app/services/admin/admin.service.ts
+++ b/src/app/services/admin/admin.service.ts
@@ -28,12 +28,12 @@ export class AdminService {
     return this.http.get<UserList>(this.rolesUrl.getUsersOfUsername(), { params });
   }
 
-  addRoleToUser(id: string, role: string) {
-    return this.http.put<UserList>(this.rolesUrl.promote(id, role), {});
+  addRoleToUser(userId: string, role: string) {
+    return this.http.patch(this.rolesUrl.promote, { userId, role });
   }
 
-  removeRoleFromUser(id: string, role: string) {
-    return this.http.put<UserList>(this.rolesUrl.demote(id, role), {});
+  removeRoleFromUser(userId: string, role: string) {
+    return this.http.patch(this.rolesUrl.demote, { userId, role });
   }
 
   getActivityLogs(options?: SearchOptionsWithPaginationAndOrdering) {

--- a/src/app/services/auth/auth.service.spec.ts
+++ b/src/app/services/auth/auth.service.spec.ts
@@ -30,7 +30,7 @@ describe('AuthService', () => {
         done();
       });
 
-      const request = httpTest.expectOne(service.url.usernameExists(username));
+      const request = httpTest.expectOne((req) => req.url.startsWith(service.url.usernameExists));
       request.flush(null, {
         status: HttpStatusCode.Ok,
         statusText: 'Ok',
@@ -46,7 +46,7 @@ describe('AuthService', () => {
         done();
       });
 
-      const request = httpTest.expectOne(service.url.usernameExists(username));
+      const request = httpTest.expectOne((req) => req.url.startsWith(service.url.usernameExists));
       request.flush(null, {
         status: HttpStatusCode.NotFound,
         statusText: 'Not found',

--- a/src/app/services/auth/auth.service.ts
+++ b/src/app/services/auth/auth.service.ts
@@ -1,6 +1,5 @@
-import { HttpClient } from '@angular/common/http';
+import { HttpClient, HttpParams } from '@angular/common/http';
 import { inject, Injectable } from '@angular/core';
-import { UserState } from '../../store/user/user.store';
 import { api } from '../../common/api';
 import { catchError, map, of } from 'rxjs';
 import type { AuthBody, SuccessfulAuthResponse } from './types';
@@ -26,21 +25,12 @@ export class AuthService {
   }
 
   checkIfUsernameExists(username: string) {
-    return this.http.get(this.url.usernameExists(username))
+    const params = new HttpParams().append('username', username);
+    return this.http.get(this.url.usernameExists, { params })
       .pipe(
         map(() => true),
         catchError(() => of(false)),
     );
-  }
-
-  getProfile(userId: string) {
-    return this.http.get<UserState>(this.url.profile(userId));
-  }
-
-  getProfileByUsername(username: string) {
-    return this.http.get<UserState>(this.url.getProfileByUsername(username), {
-      responseType: 'json',
-    });
   }
 
   retrieveSession() {

--- a/src/app/services/profile/profile.service.spec.ts
+++ b/src/app/services/profile/profile.service.spec.ts
@@ -1,0 +1,20 @@
+import { TestBed } from '@angular/core/testing';
+
+import { ProfileService } from './profile.service';
+import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
+
+describe('ProfileService', () => {
+  let service: ProfileService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [provideHttpClient(), provideHttpClientTesting()],
+    });
+    service = TestBed.inject(ProfileService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/services/profile/profile.service.ts
+++ b/src/app/services/profile/profile.service.ts
@@ -1,7 +1,7 @@
 import { inject, Injectable } from '@angular/core';
 import { api } from '../../common/api';
 import { HttpClient } from '@angular/common/http';
-import { User } from '../admin/searchTable.types';
+import { User, UserList } from '../admin/searchTable.types';
 import { SearchProfilesParameters } from '../../types/search';
 import { paramsBuilder } from '../../util/paramsBuilder';
 
@@ -18,7 +18,7 @@ export class ProfileService {
 
   searchProfiles(searchParams: SearchProfilesParameters) {
     const params = paramsBuilder(searchParams);
-    return this.http.get<User[]>(this.url.search, {
+    return this.http.get<UserList>(this.url.search, {
       params,
     });
   }

--- a/src/app/services/profile/profile.service.ts
+++ b/src/app/services/profile/profile.service.ts
@@ -1,0 +1,16 @@
+import { inject, Injectable } from '@angular/core';
+import { api } from '../../common/api';
+import { HttpClient } from '@angular/common/http';
+import { User } from '../admin/searchTable.types';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class ProfileService {
+  readonly url = api.endpoints.profiles;
+  private readonly http = inject(HttpClient);
+
+  getProfileByUsername(username: string) {
+    return this.http.get<User>(this.url.getByUsername(username));
+  }
+}

--- a/src/app/services/profile/profile.service.ts
+++ b/src/app/services/profile/profile.service.ts
@@ -2,6 +2,8 @@ import { inject, Injectable } from '@angular/core';
 import { api } from '../../common/api';
 import { HttpClient } from '@angular/common/http';
 import { User } from '../admin/searchTable.types';
+import { SearchProfilesParameters } from '../../types/search';
+import { paramsBuilder } from '../../util/paramsBuilder';
 
 @Injectable({
   providedIn: 'root',
@@ -12,5 +14,12 @@ export class ProfileService {
 
   getProfileByUsername(username: string) {
     return this.http.get<User>(this.url.getByUsername(username));
+  }
+
+  searchProfiles(searchParams: SearchProfilesParameters) {
+    const params = paramsBuilder(searchParams);
+    return this.http.get<User[]>(this.url.search, {
+      params,
+    });
   }
 }

--- a/src/app/services/quiz/quiz.service.ts
+++ b/src/app/services/quiz/quiz.service.ts
@@ -44,13 +44,13 @@ export class QuizService {
     let params = paramsBuilder(options);
     params = params.append('search', query);
 
-    return this.http.get<QuizList>(this.url.search, { params });
+    return this.http.get<QuizList>(this.url.browse, { params });
   }
 
   getAllQuizzes(options?: SearchOptions) {
     const params = paramsBuilder(options);
 
-    return this.http.get<QuizList>(this.url.all, { params });
+    return this.http.get<QuizList>(this.url.browse, { params });
   }
 
   getUserQuizzes(userId: string, options?: SearchOptions) {

--- a/src/app/services/quiz/quiz.service.ts
+++ b/src/app/services/quiz/quiz.service.ts
@@ -3,7 +3,7 @@ import { inject, Injectable } from '@angular/core';
 import { api } from '../../common/api';
 import { CreatedQuizResponse, EditQuizForm, QuizDetails, QuizList, type QuizFormSubmission } from './types';
 import { paramsBuilder } from '../../util/paramsBuilder';
-import { SearchOptions } from '../../types/search';
+import { SearchOptions, SearchQuizParameters } from '../../types/search';
 
 @Injectable({
   providedIn: 'root',
@@ -25,6 +25,12 @@ export class QuizService {
     createdOn: '',
     updatedOn: '',
   };
+
+  search(searchParameters: SearchQuizParameters) {
+    const params = paramsBuilder(searchParameters);
+
+    return this.http.get<QuizList>(this.url.browse, { params });
+  }
 
   create(quiz: QuizFormSubmission) {
     return this.http.post<CreatedQuizResponse>(this.url.create, quiz);

--- a/src/app/services/quiz/quiz.service.ts
+++ b/src/app/services/quiz/quiz.service.ts
@@ -3,7 +3,7 @@ import { inject, Injectable } from '@angular/core';
 import { api } from '../../common/api';
 import { CreatedQuizResponse, EditQuizForm, QuizDetails, QuizList, type QuizFormSubmission } from './types';
 import { paramsBuilder } from '../../util/paramsBuilder';
-import { SearchOptions, SearchQuizParameters } from '../../types/search';
+import { SearchQuizParameters } from '../../types/search';
 
 @Injectable({
   providedIn: 'root',
@@ -38,25 +38,6 @@ export class QuizService {
 
   getById(id: number) {
     return this.http.get<QuizDetails>(this.url.id(id));
-  }
-
-  getQuizzesByTitle(query: string, options?: SearchOptions) {
-    let params = paramsBuilder(options);
-    params = params.append('search', query);
-
-    return this.http.get<QuizList>(this.url.browse, { params });
-  }
-
-  getAllQuizzes(options?: SearchOptions) {
-    const params = paramsBuilder(options);
-
-    return this.http.get<QuizList>(this.url.browse, { params });
-  }
-
-  getUserQuizzes(userId: string, options?: SearchOptions) {
-    const params = paramsBuilder(options);
-
-    return this.http.get<QuizList>(this.url.user(userId), { params });
   }
 
   deleteQuiz(id: number) {

--- a/src/app/services/search-results/search-results.service.ts
+++ b/src/app/services/search-results/search-results.service.ts
@@ -1,7 +1,7 @@
 import { inject, Injectable } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { map, combineLatest } from 'rxjs';
-import { order, quizSort } from '../../common/sort';
+import { order, quizSort, sorting } from '../../common/sort';
 
 @Injectable({
   providedIn: 'root',
@@ -11,22 +11,37 @@ export class SearchResultsService {
   private readonly queryParams = this.activatedRoute.queryParamMap;
 
   private readonly _orderQuery$ = this.queryParams.pipe(
-    map(qp => qp.get('order') as order),
+    map(qp => qp.get('order') as order || sorting.order[0]),
   );
 
   private readonly _sortQuery$ = this.queryParams.pipe(
-    map(qp => qp.get('sort') as quizSort),
+    map(qp => qp.get('sortBy') as quizSort || sorting.categories[0]),
   );
 
   private readonly _pageQuery$ = this.queryParams.pipe(
     map(qp => qp.get('page')),
-    map(page => Number(page)),
+    map(page => Number(page) || 1),
+  );
+
+  private readonly _pageSizeQuery$ = this.queryParams.pipe(
+    map(qp => qp.get('pageSize')),
+    map(pageSize => Number(pageSize) || 5),
   );
 
   readonly searchOptions$ = combineLatest(
-      [this._orderQuery$, this._sortQuery$, this._pageQuery$],
+      [
+        this._orderQuery$,
+        this._sortQuery$,
+        this._pageQuery$,
+        this._pageSizeQuery$,
+      ],
     )
     .pipe(
-      map(options => ({ sort: options[1], order: options[0], page: options[2] })),
+      map(options => ({
+        order: options[0],
+        sortBy: options[1],
+        page: options[2],
+        pageSize: options[3],
+      })),
     );
 }

--- a/src/app/types/search.ts
+++ b/src/app/types/search.ts
@@ -1,3 +1,4 @@
+import { role } from '../common/roles';
 import { order, quizSort } from '../common/sort';
 
 export interface SearchOptionsWithPagination {
@@ -15,6 +16,22 @@ export interface SearchOptionsWithOrdering {
 export type SearchOptionsWithPaginationAndOrdering = SearchOptionsWithOrdering & SearchOptionsWithPagination;
 
 export type SearchOptions = SearchOptionsWithOrdering & SearchOptionsWithSorting & SearchOptionsWithPagination;
+
+export type SearchQuizParameters = Partial<{
+  page: number;
+  pageSize: number;
+  order: order;
+  sortBy: quizSort;
+  author: string;
+}>;
+
+export type SearchProfilesParameters = Partial<{
+  username: string;
+  order: order;
+  roles: role[];
+  page: number;
+  pageSize: number;
+}>;
 
 export type PaginatedResult<T, TKey extends string> = {
   total: number;

--- a/src/app/types/search.ts
+++ b/src/app/types/search.ts
@@ -23,6 +23,7 @@ export type SearchQuizParameters = Partial<{
   order: order;
   sortBy: quizSort;
   author: string;
+  title: string;
 }>;
 
 export type SearchProfilesParameters = Partial<{

--- a/src/app/util/paramsBuilder.ts
+++ b/src/app/util/paramsBuilder.ts
@@ -10,7 +10,14 @@ export function paramsBuilder(options: Record<string, any> | undefined) {
 
   for (const key of Object.keys(options)) {
     const value = options[key as string];
-    if (value !== undefined) {
+
+    if (value === undefined) continue;
+
+    if (Array.isArray(value)) {
+      value.forEach(v => {
+        params = params.append(key, String(v));
+      });
+    } else {
       params = params.append(key, String(value));
     }
   }


### PR DESCRIPTION
The .NET backend API for the app recently transitioned to a new version, which introduced some breaking changes.

Most of the migrations here weren't significant. They include the following:

- the search query params for sorting and ordering were changed (more specifically PascalCased) as the API stopped accepting the short versions
- an entire new service called ``ProfileService`` was created. The API moved the profile retrieval and the user search functionalities to the profile endpoint. As a result, the ``AuthService`` and the ``AdminService`` do not bother with retrieving those anymore
- the ``all``, ``search``, and ``user`` endpoints for searching quizzes were all merged in one endpoint on the backend. As a result, the client also merged the search into one method and has removed all separate methods
- outside of this, some endpoints also changed their URLs with minimal, if any, changes to the end results

I also used this as an opportunity to remove some reactivity hells (more specifically subscribing to observables only to set a signal value), instead resorting to just displaying them in the templates with an ``AsyncPipe``

All tests should pass. As a matter of fact, they required very little updating, mostly some typing issues (due to changes in the API object and service methods) and only two tests failed explicitly (due to the query parameter for ``sort`` being changed to ``sortBy`` on the backend)